### PR TITLE
docs: rewrite README with a "Why loupe" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,91 @@
 # loupe
 
-AI pull-request reviewer that posts **inline, line-anchored comments** (with an
-Approve-less `COMMENT` / `REQUEST_CHANGES` verdict), is **harness-agnostic**
-(review with the Claude, Codex, … agent CLIs), and enforces **each repo's own
-conventions** by reading its `CLAUDE.md` / `AGENTS.md` at review time — no
-vendored rules, nothing to keep in sync.
+A harness- and model-agnostic AI pull-request reviewer. Define as many focused
+reviewers as you want, run them from your terminal or as a GitHub Action, and
+get **real GitHub reviews with inline, line-anchored comments** — not just a
+wall-of-text PR comment.
 
 **Docs:** [`docs/`](docs/README.md) — user guide, configuration, credentials,
 GitHub Action, and the maintainer architecture reference.
 
+## Why loupe
+
+- **One reviewer is a blurry reviewer.** A single mega-prompt that tries to
+  catch bugs *and* migration risk *and* security *and* conventions does none of
+  them well. loupe lets you define **multiple focused reviewers** — each with its
+  own prompt, file globs, model, and reasoning effort — so a bug-hunter reads the
+  source, a migration-risk reviewer reads the SQL, a security reviewer reads the
+  auth code. Each posts its own labeled review, and a reviewer whose globs match
+  nothing stays quiet.
+- **Any harness, any model — your choice, not the vendor's.** loupe drives the
+  agent CLI you already use — [whip](https://github.com/context-labs/whip),
+  Claude, Codex — as a subprocess, and any model those can reach. Pick the
+  harness, model, and effort *per reviewer*. Hosted reviewers like Bugbot lock
+  you to their backend and their model; loupe doesn't — point it at a frontier
+  closed model, a fast open one, or a whole panel of them.
+- **Local and CI are the same engine.** The exact review that runs in the GitHub
+  Action runs from your terminal with one command — `--dry-run` to preview
+  without posting. No separate local path to drift, no "works in CI only".
+- **It reads the repo's own rules.** loupe enforces each repo's
+  `CLAUDE.md` / `AGENTS.md` at review time — no vendored rulebook to copy around
+  and keep in sync.
+- **A panel of models for the hard calls.** Agentic reviewers can fan out
+  subagents across a diverse set of models to independently double- or
+  triple-confirm a suspected bug before flagging it — fewer false positives, and
+  the confident ones land as inline comments.
+
 ## How it works
 
 ```
-pull_request event
-  └─ @loupe/action        reads config from env, resolves harness credentials
-       ├─ @loupe/core     fetch PR + conventions → prompt → run harness →
-       │                  validate findings against the diff → POST /pulls/{n}/reviews
-       ├─ @loupe/harness  the agent CLI as a subprocess (claude, codex, …)
+pull_request event  (or `loupe review` locally, or an @loupe comment)
+  └─ @loupe/action        reads config from env/flags, resolves harness credentials
+       ├─ @loupe/core     fetch PR + conventions → build prompt → run harness →
+       │                  parse + validate findings against the diff →
+       │                  POST /pulls/{n}/reviews (inline comments + rich body)
+       ├─ @loupe/harness  the agent CLI as a subprocess (whip, claude, codex, …)
        └─ @loupe/credentials  provider chain: env → dotenv → infisical → your own
 ```
 
-A finding must anchor to a line that appears in the diff; GitHub 422s the whole
-review otherwise, so off-diff findings degrade to notes in the summary rather
-than failing the run.
+A finding must anchor to a line that appears in the diff (GitHub 422s the whole
+review otherwise); off-diff findings snap to the nearest changed line or degrade
+to notes in the summary rather than failing the run. The review body is rendered
+from structured output — summary, concerns, highlights, and an optional
+diagram — not a restatement of the diff.
 
-## Use it in a repo
-
-See `.github/workflows/review.example.yml`. Minimal:
-
-```yaml
-- uses: actions/checkout@v4
-- uses: your-org/loupe@v0
-  with: { harness: claude }
-  env: { ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }} }
-```
-
-## Run it locally (end-to-end test)
+## Run it locally
 
 ```bash
 bun install
+# whip self-authenticates from its own local login — no keys to wire:
+bun run packages/action/src/cli.ts review owner/repo#123 --harness whip
+
+# or bring a key for a hosted harness:
 ANTHROPIC_API_KEY=sk-... \
-  bun run packages/action/src/cli.ts review https://github.com/owner/repo/pull/123
-# or the shorthand:
-bun run packages/action/src/cli.ts review owner/repo#123 --harness claude
+  bun run packages/action/src/cli.ts review owner/repo#123 --harness claude
 ```
 
 Token comes from `--token`, else `GITHUB_TOKEN`, else `gh auth token`.
 
 Key flags (defaults in parens): `--harness` (whip), `--model` (kimi-k3),
-`--reasoning low|medium|high` (medium), `--prompt-file <path>` (custom reviewer
-guidance), `--dir` (subdir scope), `--providers env,dotenv,infisical` (env),
-`--dry-run`, `--conventions`, `--workdir`, `--infisical-env`,
-`--infisical-project`.
+`--reasoning low|medium|high` (low), `--profile quiet|chill|assertive` (chill),
+`--config <path>` (focused reviewers), `--reviewer <name>` (run just one),
+`--prompt-file <path>` (custom guidance), `--dir` (subdir scope), `--ensemble`
+(multi-model majority), `--timezone`, `--no-verify`, `--no-agentic`,
+`--providers env,dotenv,infisical`, `--dry-run`.
 
-```bash
-# defaults: whip + kimi-k3 + medium
-bun run packages/action/src/cli.ts review owner/repo#123
-
-# pick model + effort + a different harness
-bun run packages/action/src/cli.ts review owner/repo#123 \
-  --harness claude --model claude-opus-4-8 --reasoning high
-
-# bring your own reviewer prompt
-bun run packages/action/src/cli.ts review owner/repo#123 \
-  --prompt-file examples/loupe-prompt.md
-```
-
-Use `--dry-run` to compute and log the review (with `LOG_LEVEL=debug` to see the
-raw harness output) without posting anything — the safe way to test.
-
-## Custom reviewer prompt
-
-The system prompt has three layers. `--prompt-file` (CLI) / `prompt-file` input
-(Action) / `LOUPE_PROMPT_FILE` replaces only the first:
-
-1. **Reviewer guidance** — persona and priorities. Default is a high-signal
-   senior-reviewer prompt; your file replaces it.
-2. **Reasoning note** — from `--reasoning`, always appended.
-3. **Output contract + headless directive** — always appended; this is why a
-   custom prompt can't break JSON parsing or trigger tool loops.
-
-See `examples/loupe-prompt.md` for the shape — write only persona/priorities,
-never the JSON schema.
+Use `--dry-run` (with `LOG_LEVEL=debug` to see raw harness output) to compute and
+log a review without posting — the safe way to test.
 
 ## Focused reviewers (`.loupe.json`)
 
-Instead of one generic reviewer, define several focused ones — each with its own
-prompt, the file globs it applies to, and optional model/reasoning. loupe runs
-every reviewer whose globs match a changed file and posts each as its own
-labeled review (`🔍 loupe · migrations`). A reviewer whose globs match nothing is
-skipped, so the migration reviewer only fires when a migration changes.
+Instead of one generic reviewer, define several — each with its own prompt, the
+file globs it applies to, and optional model/reasoning/profile. loupe runs every
+reviewer whose globs match a changed file and posts each as its own labeled
+review (`🔍 loupe · migrations`). A reviewer whose globs match nothing is skipped.
 
 ```json
 {
+  "skills": [".agents/skills/i-have-adhd"],
   "reviewers": [
     {
       "name": "bugs",
@@ -111,25 +104,37 @@ skipped, so the migration reviewer only fires when a migration changes.
 }
 ```
 
-Run all matching reviewers, or just one:
+Per-reviewer keys: `prompt`/`promptFile`, `include`/`exclude`, `model`,
+`reasoning`, `profile`, `agentic`, `verify`, `ensemble`, `skills`,
+`pathInstructions`. Top-level `skills` apply to every reviewer.
 
 ```bash
 loupe review owner/repo#123 --config .loupe.json
 loupe review owner/repo#123 --config .loupe.json --reviewer migrations
 ```
 
-In the Action, set `LOUPE_CONFIG` to the checked-out `.loupe.json` (promptFiles
-resolve relative to it). See `examples/.loupe.json` and `examples/reviewers/`
-for a ready bug-hunter + migration-risk pair.
+See `examples/.loupe.json` and `examples/reviewers/` for a ready bug-hunter +
+migration-risk pair.
+
+## Custom reviewer prompt
+
+The system prompt is layered. `--prompt-file` (CLI) / `prompt-file` input
+(Action) / a reviewer's `promptFile` replaces only the **guidance** layer
+(persona + priorities). loupe always appends the reasoning note, profile
+directive, tool-access directive, repo conventions, and the JSON output
+contract — so a custom prompt can't break parsing or trigger tool loops. Write
+only persona/priorities; never the JSON schema. See `examples/loupe-prompt.md`.
 
 ## GitHub integration
 
 `action.yml` is a composite Action. Copy `.github/workflows/review.example.yml`
-into a consuming repo (it has three ready variants: internal whip, external
-claude-with-secret, and custom-prompt), or register it once at the org level as
-a required workflow so it applies to every repo. Inputs mirror the CLI flags:
-`harness`, `model`, `reasoning`, `prompt-file`, `dir`, `convention-paths`,
-`credential-providers`, `github-token`.
+into a consuming repo, or register it once at the org level. A second workflow on
+comment events gives you **`@loupe` chat**: `@loupe review` (re-review),
+`@loupe fix <what>` (loupe edits the branch and pushes a commit),
+`@loupe <question>` (Q&A grounded in the diff), and `@loupe help`. Inputs mirror
+the CLI flags: `harness`, `model`, `reasoning`, `profile`, `config`, `reviewer`,
+`prompt-file`, `dir`, `skills`, `ensemble`, `timezone`, `verify`, `full`,
+`convention-paths`, `credential-providers`, `github-token`.
 
 ## Scope to a subdirectory
 
@@ -138,33 +143,31 @@ are reviewed, conventions are read from it (`inference/AGENTS.md`), and the
 harness runs there:
 
 ```bash
-bun run packages/action/src/cli.ts review context-labs/monorepo#6046 \
-  --harness whip --dir inference
+loupe review context-labs/monorepo#6046 --harness whip --dir inference
 ```
 
 In the Action, set the `dir` input (or `LOUPE_DIR`).
 
-## Logging
-
-Structured logging via winston. `LOG_LEVEL` (`debug|info|warn|error`, default
-`info`) controls verbosity; pretty output locally, JSON under `CI=true`. Set
-`OTEL_EXPORTER_OTLP_ENDPOINT` to also export logs to an OTLP collector (via the
-winston→OpenTelemetry bridge, same as the monorepo) — otherwise logs stay
-stdout-only, so no collector is needed to run.
-
 ## Credentials
 
-`LOUPE_CREDENTIAL_PROVIDERS` is an ordered chain; first hit wins. Ships with:
-
-Harnesses that self-authenticate need no provider at all. `whip` reviews using
+Harnesses that self-authenticate need no provider at all: `whip` reviews using
 its own local login (`~/.whip/`), so `loupe review --harness whip` just works
-once `whip auth inference-net login` has been run — no keys to wire.
+once `whip auth inference-net login` has been run.
+
+Otherwise `LOUPE_CREDENTIAL_PROVIDERS` is an ordered chain; first hit wins:
 
 - `env` — `process.env` (default; works with plain GitHub secrets)
 - `dotenv` — a `.env` file
 - `infisical` — the Infisical CLI (`LOUPE_INFISICAL_ENV`, `LOUPE_INFISICAL_PROJECT_ID`)
 
 Add your own by implementing `CredentialProvider` from `@loupe/credentials`.
+
+## Logging
+
+Structured logging via winston. `LOG_LEVEL` (`debug|info|warn|error`, default
+`info`); pretty locally, JSON under `CI=true`. Set `OTEL_EXPORTER_OTLP_ENDPOINT`
+to also export logs to an OTLP collector — otherwise logs stay stdout-only, so no
+collector is needed to run.
 
 ## Dev
 
@@ -173,9 +176,6 @@ bun install
 task check   # format + lint + tsc + test
 ```
 
-## Status: v0.1
-
-Working: claude harness, inline review posting, convention-reading, credential
-chain (env/dotenv/infisical). Codex harness is wired but unverified end-to-end.
-Not yet: incremental review on `synchronize` (re-reviews the full diff each run),
-comment de-duplication across runs, cost controls.
+Bun workspace monorepo: `@loupe/credentials`, `@loupe/harness`, `@loupe/logger`,
+`@loupe/core`, `@loupe/action`. Tooling mirrors the inference monorepo
+(oxlint / oxfmt / typescript-7 / Taskfile).


### PR DESCRIPTION
Refreshes the stale README (it still said "v0.1" and led with the claude harness) and adds a **Why loupe** motivation section in the style of whip's README.

The four bets, front and center:
- **Multiple focused reviewers** — each with its own prompt, globs, model, and reasoning, instead of one blurry mega-prompt.
- **Any harness, any model** — drives whip/Claude/Codex as a subprocess and any model they reach; not locked to a vendor backend like Bugbot.
- **Same engine locally and in CI** — the Action review runs verbatim from the terminal, `--dry-run` to preview.
- **Reads the repo's own `CLAUDE.md`/`AGENTS.md`** — no vendored rulebook to sync.
- Plus: a **panel of models** for double/triple-confirming the hard calls.

Also brings the feature docs current: whip default, `@loupe` chat/fix, rich structured review body, profiles, ensemble, skills, subdir scoping, line-snapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)