### PR TITLE
feat(config): top-level harness/model + whip panel in .loupe.json

### DIFF
--- a/.github/workflows/review.example.yml
+++ b/.github/workflows/review.example.yml
@@ -48,3 +48,24 @@ jobs:
         with:
           harness: whip
           prompt-file: .github/loupe-prompt.md
+
+  # --- Variant D: config-driven (recommended for multiple repos) ------------
+  # Put ALL review policy in .loupe.json — harness, model, timezone, dir, the
+  # whip provider + model panel, and the reviewers. The workflow then only
+  # provisions: checkout, the harness binary, and the secret. Nothing to repeat
+  # across repos or between the review and chat workflows.
+  review-config:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # if you fetch the key from an OIDC secrets manager
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      # install your harness binary here (e.g. curl the whip release), then:
+      - uses: context-labs/loupe@v0
+        with:
+          config: .loupe.json # harness/model/timezone/dir/whip all live here
+        env:
+          # only the secret value stays in the workflow; its NAME is in .loupe.json
+          INFERENCE_API_KEY: ${{ secrets.INFERENCE_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -108,6 +108,42 @@ Per-reviewer keys: `prompt`/`promptFile`, `include`/`exclude`, `model`,
 `reasoning`, `profile`, `agentic`, `verify`, `ensemble`, `skills`,
 `pathInstructions`. Top-level `skills` apply to every reviewer.
 
+### Top-level config — keep review policy out of the workflow
+
+The config file also carries the **review defaults** that used to be repeated in
+every workflow file: `harness`, `model`, `reasoning`, `profile`, `timezone`, and
+`dir`. Precedence is **Action input / CLI flag → `.loupe.json` → built-in
+default**, so a workflow can still override, but by default the policy lives with
+the repo.
+
+It can also declare the **whip provider + model panel** under `whip`, so the
+workflow no longer hand-writes `~/.whip/config.json` in a CI step. loupe
+materializes it into a throwaway `WHIP_HOME` at review time (never touching a
+developer's real `~/.whip`); only the API key *value* stays in the workflow —
+its env-var name is in the config.
+
+```json
+{
+  "harness": "whip",
+  "model": "kimi-k3",
+  "timezone": "PST",
+  "dir": "inference",
+  "whip": {
+    "provider": {
+      "name": "inference-net",
+      "baseUrl": "https://api.inference.net/v1",
+      "apiKeyEnv": "INFERENCE_API_KEY"
+    },
+    "models": ["kimi-k3", "glm-5.3-flash", "gpt-5.6-luna"]
+  },
+  "reviewers": [{ "name": "bugs", "promptFile": "reviewers/bugs.md" }]
+}
+```
+
+With that, the whole workflow is just: checkout → install the harness binary →
+`context-labs/loupe@v0` with `config: .loupe.json` and the secret in `env`. See
+Variant D in `.github/workflows/review.example.yml`.
+
 ```bash
 loupe review owner/repo#123 --config .loupe.json
 loupe review owner/repo#123 --config .loupe.json --reviewer migrations

--- a/action.yml
+++ b/action.yml
@@ -8,18 +8,21 @@ inputs:
     description: "Token used to read the PR and post the review."
     required: true
     default: ${{ github.token }}
+  # harness/model/reasoning/profile/timezone/dir default to empty so a value in
+  # .loupe.json wins; set an input here only to override the file. Built-in
+  # fallbacks (whip / kimi-k3 / low / chill / UTC) apply when neither is set.
   harness:
-    description: "Which agent CLI to review with (whip, claude, codex)."
+    description: "Which agent CLI to review with (whip, claude, codex). Overrides .loupe.json; default whip."
     required: false
-    default: "whip"
+    default: ""
   model:
-    description: "Model id for the harness (e.g. kimi-k3, claude-opus-4-8)."
+    description: "Model id for the harness (e.g. kimi-k3, claude-opus-4-8). Overrides .loupe.json; default kimi-k3."
     required: false
-    default: "kimi-k3"
+    default: ""
   reasoning:
-    description: "Reasoning effort: low, medium, or high."
+    description: "Reasoning effort: low, medium, or high. Overrides .loupe.json; default low."
     required: false
-    default: "low"
+    default: ""
   prompt-file:
     description: "Path to a custom reviewer-guidance file (output contract still enforced)."
     required: false
@@ -33,7 +36,7 @@ inputs:
     required: false
     default: "CLAUDE.md,AGENTS.md,.loupe.md,CONTRIBUTING.md"
   dir:
-    description: "Restrict the review to a repo subdirectory (e.g. inference)."
+    description: "Restrict the review to a repo subdirectory (e.g. inference). Overrides .loupe.json."
     required: false
     default: ""
   config:
@@ -45,9 +48,9 @@ inputs:
     required: false
     default: ""
   profile:
-    description: "Noise profile: quiet | chill | assertive."
+    description: "Noise profile: quiet | chill | assertive. Overrides .loupe.json; default chill."
     required: false
-    default: "chill"
+    default: ""
   verify:
     description: "Run the second-opinion verification pass (true/false)."
     required: false
@@ -65,9 +68,9 @@ inputs:
     required: false
     default: ""
   timezone:
-    description: "Timezone label for the review environment line (e.g. PST)."
+    description: "Timezone label for the review environment line (e.g. PST). Overrides .loupe.json; default UTC."
     required: false
-    default: "UTC"
+    default: ""
 runs:
   using: "composite"
   steps:

--- a/examples/.loupe.json
+++ b/examples/.loupe.json
@@ -1,4 +1,25 @@
 {
+  "harness": "whip",
+  "model": "kimi-k3",
+  "timezone": "PST",
+  "dir": "inference",
+  "whip": {
+    "provider": {
+      "name": "inference-net",
+      "label": "Inference.net",
+      "baseUrl": "https://api.inference.net/v1",
+      "apiKeyEnv": "INFERENCE_API_KEY"
+    },
+    "defaultModel": "kimi-k3",
+    "models": [
+      "kimi-k3",
+      "kimi-k3-fast",
+      "glm-5.3-flash",
+      "glm-5.2-fast",
+      "deepseek-v4-pro-0813",
+      "gpt-5.6-luna"
+    ]
+  },
   "reviewers": [
     {
       "name": "bugs",

--- a/packages/action/src/cli.ts
+++ b/packages/action/src/cli.ts
@@ -7,7 +7,7 @@ import { createRootLogger, shutdownLogger } from "@loupe/logger";
 import { Command } from "commander";
 
 import { resolveProviders } from "./config";
-import { loadReviewers } from "./reviewers";
+import { loadReviewers, loadSettings } from "./reviewers";
 import { formatResult, renderReview, reviewPullRequest } from "./run";
 
 const REASONING: readonly ReasoningEffort[] = ["low", "medium", "high"];
@@ -68,9 +68,12 @@ program
   .command("review")
   .description("Review a pull request and post inline comments")
   .argument("<pr>", "PR URL (github.com/owner/repo/pull/N) or owner/repo#N")
-  .option("-H, --harness <name>", "agent CLI to review with", "whip")
-  .option("-m, --model <name>", "model id for the harness", "kimi-k3")
-  .option("-r, --reasoning <level>", "reasoning effort: low|medium|high", "low")
+  .option("-H, --harness <name>", "agent CLI to review with (default whip)")
+  .option("-m, --model <name>", "model id for the harness (default kimi-k3)")
+  .option(
+    "-r, --reasoning <level>",
+    "reasoning effort: low|medium|high (default low)",
+  )
   .option(
     "--prompt-file <path>",
     "custom reviewer guidance replacing the default (output contract still enforced)",
@@ -100,12 +103,11 @@ program
     "--no-agentic",
     "review one-shot from the diff only, instead of exploring the checkout with tools",
   )
-  .option("--profile <name>", "noise profile: quiet|chill|assertive", "chill")
   .option(
-    "--timezone <tz>",
-    "timezone label for the review environment line",
-    "UTC",
+    "--profile <name>",
+    "noise profile: quiet|chill|assertive (default chill)",
   )
+  .option("--timezone <tz>", "timezone label for the review environment line")
   .option(
     "--ensemble <models>",
     "comma-separated models to ensemble; keep findings a majority agree on",
@@ -127,9 +129,9 @@ program
     async (
       pr: string,
       opts: {
-        harness: string;
-        model: string;
-        reasoning: string;
+        harness?: string;
+        model?: string;
+        reasoning?: string;
         promptFile?: string;
         providers: string;
         token?: string;
@@ -139,8 +141,8 @@ program
         config?: string;
         reviewer?: string;
         agentic: boolean;
-        profile: string;
-        timezone: string;
+        profile?: string;
+        timezone?: string;
         ensemble?: string;
         skills?: string;
         verify: boolean;
@@ -153,6 +155,19 @@ program
       const logger = createRootLogger("loupe-cli");
       try {
         const { owner, repo, pullNumber } = parsePr(pr);
+        // Top-level review defaults from .loupe.json; a flag overrides the file,
+        // the file overrides loupe's built-in default.
+        const settings = opts.config ? loadSettings(opts.config) : {};
+        const harnessName = opts.harness ?? settings.harness ?? "whip";
+        const model = opts.model ?? settings.model ?? "kimi-k3";
+        const reasoning = parseReasoning(
+          opts.reasoning ?? settings.reasoning ?? "low",
+        );
+        const profile = parseProfile(
+          opts.profile ?? settings.profile ?? "chill",
+        );
+        const timezone = opts.timezone ?? settings.timezone ?? "UTC";
+        const subdir = opts.dir ?? settings.dir;
         const ensembleModels = opts.ensemble
           ? opts.ensemble
               .split(",")
@@ -170,7 +185,7 @@ program
           owner,
           repo,
           pullNumber,
-          harnessName: opts.harness,
+          harnessName,
           workdir: opts.workdir,
           conventionPaths: opts.conventions
             .split(",")
@@ -180,13 +195,14 @@ program
             env: opts.infisicalEnv,
             projectId: opts.infisicalProject,
           }),
-          subdir: opts.dir,
+          subdir,
           dryRun: opts.dryRun,
           verify: opts.verify,
           full: opts.full,
           ensembleModels,
           skills,
-          timezone: opts.timezone,
+          timezone,
+          whipConfig: settings.whip,
         };
 
         if (opts.config) {
@@ -209,9 +225,9 @@ program
               include: r.include,
               exclude: r.exclude,
               agentic: r.agentic ?? opts.agentic,
-              model: r.model ?? opts.model,
-              reasoning: parseReasoning(r.reasoning ?? opts.reasoning),
-              profile: r.profile ?? parseProfile(opts.profile),
+              model: r.model ?? model,
+              reasoning: r.reasoning ? parseReasoning(r.reasoning) : reasoning,
+              profile: r.profile ?? profile,
               verify: r.verify ?? opts.verify,
               pathInstructions: r.pathInstructions,
               ensembleModels: r.ensemble ?? ensembleModels,
@@ -227,9 +243,9 @@ program
         const result = await reviewPullRequest({
           ...base,
           agentic: opts.agentic,
-          model: opts.model,
-          reasoning: parseReasoning(opts.reasoning),
-          profile: parseProfile(opts.profile),
+          model,
+          reasoning,
+          profile,
           guidance: opts.promptFile
             ? readFileSync(opts.promptFile, "utf8")
             : undefined,

--- a/packages/action/src/config.ts
+++ b/packages/action/src/config.ts
@@ -8,7 +8,16 @@ import {
   infisicalProvider,
   type CredentialProvider,
 } from "@loupe/credentials";
+import type { WhipConfig } from "@loupe/harness";
 import { z } from "zod";
+
+import { loadSettings, type LoupeSettings } from "./reviewers";
+
+/** An empty string from an unset Action input counts as "not provided". */
+const optionalInput = z
+  .string()
+  .optional()
+  .transform((v) => (v && v.trim() ? v.trim() : undefined));
 
 /**
  * All environment reading happens here, parsed with Zod, then passed inward as
@@ -21,9 +30,11 @@ const envSchema = z.object({
   GITHUB_EVENT_NAME: z.string().optional(),
   GITHUB_WORKSPACE: z.string().optional(),
   LOUPE_PR_NUMBER: z.coerce.number().int().positive().optional(),
-  LOUPE_HARNESS: z.string().default("whip"),
-  LOUPE_MODEL: z.string().default("kimi-k3"),
-  LOUPE_REASONING: z.enum(["low", "medium", "high"]).default("low"),
+  // Movable defaults: an unset input yields "" → undefined here, so a value in
+  // .loupe.json can win. Precedence (input → file → builtin) resolves below.
+  LOUPE_HARNESS: optionalInput,
+  LOUPE_MODEL: optionalInput,
+  LOUPE_REASONING: optionalInput,
   LOUPE_PROMPT_FILE: z.string().optional(),
   LOUPE_CONVENTION_PATHS: z
     .string()
@@ -31,10 +42,10 @@ const envSchema = z.object({
   LOUPE_CREDENTIAL_PROVIDERS: z.string().default("env"),
   LOUPE_INFISICAL_ENV: z.string().optional(),
   LOUPE_INFISICAL_PROJECT_ID: z.string().optional(),
-  LOUPE_DIR: z.string().optional(),
+  LOUPE_DIR: optionalInput,
   LOUPE_CONFIG: z.string().optional(),
   LOUPE_REVIEWER: z.string().optional(),
-  LOUPE_PROFILE: z.enum(["quiet", "chill", "assertive"]).default("chill"),
+  LOUPE_PROFILE: optionalInput,
   LOUPE_VERIFY: z
     .enum(["true", "false"])
     .default("true")
@@ -45,8 +56,23 @@ const envSchema = z.object({
     .transform((v) => v === "true"),
   LOUPE_ENSEMBLE: z.string().default(""),
   LOUPE_SKILLS: z.string().default(""),
-  LOUPE_TIMEZONE: z.string().default("UTC"),
+  LOUPE_TIMEZONE: optionalInput,
 });
+
+const REASONING = ["low", "medium", "high"] as const;
+const PROFILES = ["quiet", "chill", "assertive"] as const;
+
+function asReasoning(v: string | undefined): ReasoningEffort | undefined {
+  if (v === undefined) return undefined;
+  if ((REASONING as readonly string[]).includes(v)) return v as ReasoningEffort;
+  throw new Error(`Invalid reasoning "${v}". Use: ${REASONING.join(", ")}`);
+}
+
+function asProfile(v: string | undefined): Profile | undefined {
+  if (v === undefined) return undefined;
+  if ((PROFILES as readonly string[]).includes(v)) return v as Profile;
+  throw new Error(`Invalid profile "${v}". Use: ${PROFILES.join(", ")}`);
+}
 
 export type Config = {
   readonly token: string;
@@ -69,6 +95,7 @@ export type Config = {
   readonly ensembleModels: readonly string[];
   readonly skills: readonly string[];
   readonly timezone: string;
+  readonly whipConfig?: WhipConfig;
   readonly eventName?: string;
   readonly eventPath?: string;
 };
@@ -81,26 +108,33 @@ export function loadConfig(): Config {
   // own cwd (the composite action runs from its own directory).
   const inWorkspace = (p: string): string => resolve(workdir, p);
 
+  const configPath = env.LOUPE_CONFIG
+    ? inWorkspace(env.LOUPE_CONFIG)
+    : undefined;
+  // Top-level review defaults from .loupe.json. Precedence for the movable
+  // settings: Action input (explicit) → file → loupe's built-in default.
+  const file: LoupeSettings = configPath ? loadSettings(configPath) : {};
+
   return {
     token: env.GITHUB_TOKEN,
     owner,
     repo,
     pullNumber: resolvePullNumber(env.LOUPE_PR_NUMBER, env.GITHUB_EVENT_PATH),
-    harnessName: env.LOUPE_HARNESS,
+    harnessName: env.LOUPE_HARNESS ?? file.harness ?? "whip",
     workdir,
     conventionPaths: env.LOUPE_CONVENTION_PATHS.split(",")
       .map((p) => p.trim())
       .filter(Boolean),
     providers: buildProviders(env),
-    subdir: env.LOUPE_DIR,
-    model: env.LOUPE_MODEL,
-    reasoning: env.LOUPE_REASONING,
+    subdir: env.LOUPE_DIR ?? file.dir,
+    model: env.LOUPE_MODEL ?? file.model ?? "kimi-k3",
+    reasoning: asReasoning(env.LOUPE_REASONING) ?? file.reasoning ?? "low",
     guidance: env.LOUPE_PROMPT_FILE
       ? readFileSync(inWorkspace(env.LOUPE_PROMPT_FILE), "utf8")
       : undefined,
-    configPath: env.LOUPE_CONFIG ? inWorkspace(env.LOUPE_CONFIG) : undefined,
+    configPath,
     reviewerFilter: env.LOUPE_REVIEWER,
-    profile: env.LOUPE_PROFILE,
+    profile: asProfile(env.LOUPE_PROFILE) ?? file.profile ?? "chill",
     verify: env.LOUPE_VERIFY,
     full: env.LOUPE_FULL,
     ensembleModels: env.LOUPE_ENSEMBLE.split(",")
@@ -109,7 +143,8 @@ export function loadConfig(): Config {
     skills: env.LOUPE_SKILLS.split(",")
       .map((s) => s.trim())
       .filter(Boolean),
-    timezone: env.LOUPE_TIMEZONE,
+    timezone: env.LOUPE_TIMEZONE ?? file.timezone ?? "UTC",
+    whipConfig: file.whip,
     eventName: env.GITHUB_EVENT_NAME,
     eventPath: env.GITHUB_EVENT_PATH,
   };

--- a/packages/action/src/orchestrate.ts
+++ b/packages/action/src/orchestrate.ts
@@ -27,6 +27,7 @@ export async function runReviews(
     providers: config.providers,
     subdir: config.subdir,
     verify: config.verify,
+    whipConfig: config.whipConfig,
     full,
   };
 

--- a/packages/action/src/respond.ts
+++ b/packages/action/src/respond.ts
@@ -75,6 +75,7 @@ async function runFix(
     agentic: true,
     workdir: cwd,
     env,
+    whipConfig: config.whipConfig,
     logger,
   });
 
@@ -188,6 +189,7 @@ export async function handleComment(
     agentic: false,
     workdir: config.workdir,
     env,
+    whipConfig: config.whipConfig,
     logger,
   });
   const answer = stdout.trim() || "I couldn't produce an answer for that.";

--- a/packages/action/src/reviewers.ts
+++ b/packages/action/src/reviewers.ts
@@ -41,11 +41,62 @@ const reviewerSchema = z
     message: "reviewer has both prompt and promptFile; use one",
   });
 
+/** whip provider + model panel, so the review workflow needn't hand-write
+ * ~/.whip/config.json in a CI step. loupe materializes it into a throwaway
+ * WHIP_HOME at review time. */
+const whipConfigSchema = z.object({
+  provider: z.object({
+    name: z.string().min(1),
+    baseUrl: z.string().min(1),
+    apiKeyEnv: z.string().min(1),
+    label: z.string().optional(),
+  }),
+  models: z.array(z.string().min(1)).min(1),
+  defaultModel: z.string().optional(),
+});
+
 const configSchema = z.object({
   reviewers: z.array(reviewerSchema).min(1),
   /** Skills applied to every reviewer (merged with each reviewer's own). */
   skills: z.array(z.string()).optional(),
+  // Top-level review defaults. Action inputs / CLI flags override these; these
+  // in turn override loupe's built-in defaults. Keeps harness/model/timezone/dir
+  // with the repo's review policy instead of duplicated across workflow files.
+  harness: z.string().optional(),
+  model: z.string().optional(),
+  reasoning: z.enum(["low", "medium", "high"]).optional(),
+  profile: z.enum(["quiet", "chill", "assertive"]).optional(),
+  timezone: z.string().optional(),
+  dir: z.string().optional(),
+  whip: whipConfigSchema.optional(),
 });
+
+/** The top-level, non-reviewer settings from a .loupe.json — review defaults a
+ * repo declares once instead of repeating them in every workflow file. */
+export type LoupeSettings = {
+  readonly harness?: string;
+  readonly model?: string;
+  readonly reasoning?: ReasoningEffort;
+  readonly profile?: Profile;
+  readonly timezone?: string;
+  readonly dir?: string;
+  readonly whip?: z.infer<typeof whipConfigSchema>;
+};
+
+/** Read only the top-level settings from a config file (not the reviewers). */
+export function loadSettings(configPath: string): LoupeSettings {
+  const raw: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+  const c = configSchema.parse(raw);
+  return {
+    harness: c.harness,
+    model: c.model,
+    reasoning: c.reasoning,
+    profile: c.profile,
+    timezone: c.timezone,
+    dir: c.dir,
+    whip: c.whip,
+  };
+}
 
 export type Reviewer = {
   readonly name: string;

--- a/packages/action/src/run.ts
+++ b/packages/action/src/run.ts
@@ -8,7 +8,7 @@ import {
   resolveCredentials,
   type CredentialProvider,
 } from "@loupe/credentials";
-import { getHarness } from "@loupe/harness";
+import { getHarness, type WhipConfig } from "@loupe/harness";
 import type { Logger } from "@loupe/logger";
 
 export type RunInput = {
@@ -36,6 +36,7 @@ export type RunInput = {
   readonly ensembleModels?: readonly string[];
   readonly skills?: readonly string[];
   readonly timezone?: string;
+  readonly whipConfig?: WhipConfig;
   readonly logger: Logger;
 };
 
@@ -76,6 +77,7 @@ export async function reviewPullRequest(
     harness,
     workdir: input.workdir,
     harnessEnv,
+    whipConfig: input.whipConfig,
     conventionPaths: input.conventionPaths,
     subdir: input.subdir,
     dryRun: input.dryRun,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import type { Harness } from "@loupe/harness";
+import type { Harness, WhipConfig } from "@loupe/harness";
 import type { Logger } from "@loupe/logger";
 
 import {
@@ -45,6 +45,8 @@ export type ReviewRequest = {
   readonly workdir: string;
   /** Secrets to inject into the harness subprocess (e.g. ANTHROPIC_API_KEY). */
   readonly harnessEnv: Record<string, string>;
+  /** whip provider/model catalog to materialize into a throwaway WHIP_HOME. */
+  readonly whipConfig?: WhipConfig;
   /** Convention doc paths to pull from the target repo, in priority order. */
   readonly conventionPaths: readonly string[];
   /**
@@ -288,6 +290,7 @@ export async function runReview(req: ReviewRequest): Promise<ReviewResult> {
         agentic: useAgentic,
         workdir: harnessCwd,
         env: req.harnessEnv,
+        whipConfig: req.whipConfig,
         logger,
       });
     let stdout: string;
@@ -424,6 +427,7 @@ async function verifyInline(
       agentic: false,
       workdir: harnessCwd,
       env: req.harnessEnv,
+      whipConfig: req.whipConfig,
       logger: req.logger,
     });
     const verdicts = parseVerification(stdout);

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,6 +1,32 @@
 import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { Logger } from "@loupe/logger";
+
+/**
+ * A whip provider + model catalog, declared in loupe's config so the review
+ * workflow doesn't have to hand-write `~/.whip/config.json` in a CI step. When
+ * present, the whip harness materializes it into a throwaway config dir and
+ * points `WHIP_HOME` at it — never touching a developer's real `~/.whip`.
+ */
+export type WhipConfig = {
+  /** OpenAI-compatible provider whip routes through. */
+  readonly provider: {
+    /** Provider key (e.g. "inference-net"). */
+    readonly name: string;
+    readonly baseUrl: string;
+    /** Env var whip reads the API key from at runtime (e.g. "INFERENCE_API_KEY"). */
+    readonly apiKeyEnv: string;
+    /** Display label; defaults to `name`. */
+    readonly label?: string;
+  };
+  /** Models whip may route to (the panel). The first is the default if unset. */
+  readonly models: readonly string[];
+  /** Default model; defaults to the review's model, else the first in `models`. */
+  readonly defaultModel?: string;
+};
 
 /**
  * What a harness needs to run a review: the system prompt (reviewer persona +
@@ -17,6 +43,8 @@ export type HarnessContext = {
   readonly agentic?: boolean;
   readonly workdir: string;
   readonly env: Record<string, string>;
+  /** whip provider/model catalog to materialize into a throwaway WHIP_HOME. */
+  readonly whipConfig?: WhipConfig;
   readonly logger: Logger;
 };
 
@@ -216,11 +244,40 @@ function runWhipStreaming(
 }
 
 /**
+ * Materialize a WhipConfig into a throwaway config dir and return the env
+ * (WHIP_HOME) that points whip at it. Keeps loupe's `whip` block out of a
+ * developer's real ~/.whip and removes the hand-written config step from CI.
+ */
+export function materializeWhipHome(cfg: WhipConfig): Record<string, string> {
+  const dir = mkdtempSync(join(tmpdir(), "loupe-whip-"));
+  const providerKey = cfg.provider.name;
+  const defaultModel = cfg.defaultModel ?? cfg.models[0];
+  const config = {
+    defaultModel,
+    defaultProvider: providerKey,
+    providers: {
+      [providerKey]: {
+        name: cfg.provider.label ?? providerKey,
+        baseUrl: cfg.provider.baseUrl,
+        api: "openai-completions",
+        apiKeyEnv: cfg.provider.apiKeyEnv,
+      },
+    },
+    models: Object.fromEntries(
+      cfg.models.map((m) => [m, { providers: [providerKey] }]),
+    ),
+  };
+  writeFileSync(join(dir, "config.json"), JSON.stringify(config, null, 2));
+  return { WHIP_HOME: dir };
+}
+
+/**
  * whip (context-labs custom harness): runs `whip run --format json` and streams
  * the event log live. `-system` sets the reviewer/output/headless instructions.
- * It self-authenticates from its own local login (~/.whip/), so loupe injects no
- * credentials. `-max-turns` caps the tool loop as a safety net in case the model
- * ignores the headless (no-tools) directive in the system prompt.
+ * By default it self-authenticates from its own local login (~/.whip/); when a
+ * `whipConfig` is supplied, loupe writes a throwaway WHIP_HOME config declaring
+ * the provider + model panel instead. `-max-turns` caps the tool loop as a
+ * safety net in case the model ignores the headless directive.
  */
 export function whipHarness(): Harness {
   return {
@@ -243,7 +300,11 @@ export function whipHarness(): Harness {
         ctx.systemPrompt,
       ];
       if (ctx.model) args.push("-m", ctx.model);
-      return runWhipStreaming(args, ctx);
+      const whipEnv = ctx.whipConfig ? materializeWhipHome(ctx.whipConfig) : {};
+      return runWhipStreaming(args, {
+        ...ctx,
+        env: { ...ctx.env, ...whipEnv },
+      });
     },
   };
 }

--- a/packages/harness/tests/whip-config.test.ts
+++ b/packages/harness/tests/whip-config.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { materializeWhipHome, type WhipConfig } from "../src/index";
+
+const base: WhipConfig = {
+  provider: {
+    name: "inference-net",
+    baseUrl: "https://api.inference.net/v1",
+    apiKeyEnv: "INFERENCE_API_KEY",
+    label: "Inference.net",
+  },
+  models: ["kimi-k3", "glm-5.3-flash", "gpt-5.6-luna"],
+  defaultModel: "kimi-k3",
+};
+
+function writtenConfig(cfg: WhipConfig): {
+  env: Record<string, string>;
+  config: Record<string, unknown>;
+} {
+  const env = materializeWhipHome(cfg);
+  const config = JSON.parse(
+    readFileSync(join(env["WHIP_HOME"]!, "config.json"), "utf8"),
+  ) as Record<string, unknown>;
+  return { env, config };
+}
+
+describe("materializeWhipHome", () => {
+  it("writes a WHIP_HOME config with the provider and full model panel", () => {
+    const { env, config } = writtenConfig(base);
+    expect(env["WHIP_HOME"]).toBeTruthy();
+    expect(config["defaultModel"]).toBe("kimi-k3");
+    expect(config["defaultProvider"]).toBe("inference-net");
+    expect(config["providers"]).toEqual({
+      "inference-net": {
+        name: "Inference.net",
+        baseUrl: "https://api.inference.net/v1",
+        api: "openai-completions",
+        apiKeyEnv: "INFERENCE_API_KEY",
+      },
+    });
+    expect(Object.keys(config["models"] as object)).toEqual([
+      "kimi-k3",
+      "glm-5.3-flash",
+      "gpt-5.6-luna",
+    ]);
+    expect(
+      (config["models"] as Record<string, unknown>)["gpt-5.6-luna"],
+    ).toEqual({ providers: ["inference-net"] });
+  });
+
+  it("defaults defaultModel to the first model and label to the provider key", () => {
+    const { config } = writtenConfig({
+      provider: {
+        name: "inference-net",
+        baseUrl: "https://api.inference.net/v1",
+        apiKeyEnv: "INFERENCE_API_KEY",
+      },
+      models: ["glm-5.3-flash", "kimi-k3"],
+    });
+    expect(config["defaultModel"]).toBe("glm-5.3-flash");
+    expect(
+      (config["providers"] as Record<string, { name: string }>)["inference-net"]
+        ?.name,
+    ).toBe("inference-net");
+  });
+});


### PR DESCRIPTION
Answers "why is harness/model config in the CI YAML instead of `.loupe.json`?" — it moves review **policy** into the config file and leaves the workflow to do only **provisioning**.

## 1. Top-level review defaults
`.loupe.json` can now set `harness`, `model`, `reasoning`, `profile`, `timezone`, and `dir` at the top level.

Precedence: **Action input / CLI flag → `.loupe.json` → built-in default**. Action inputs now default to empty (not the old hardcoded `whip`/`kimi-k3`/…) so the file can win; loupe applies the builtin fallback when neither input nor file sets a value. A workflow can still override any of them.

## 2. `whip` provider + model panel
An optional `whip` block declares the provider and the model panel:

```json
"whip": {
  "provider": { "name": "inference-net", "baseUrl": "https://api.inference.net/v1", "apiKeyEnv": "INFERENCE_API_KEY" },
  "models": ["kimi-k3", "glm-5.3-flash", "gpt-5.6-luna"]
}
```

When present, the whip harness **materializes it into a throwaway `WHIP_HOME`** at review time (via whip's `WHIP_HOME` override — never touches a developer's real `~/.whip`). This **deletes the hand-written `~/.whip/config.json` CI step**; only the API key *value* stays in the workflow, its env-var *name* is in the config.

The payoff (Variant D in the example workflow): checkout → install harness binary → `loupe@v0` with `config: .loupe.json` + the secret. Nothing duplicated across repos or between the review and chat workflows.

## Scope
- Threads `whipConfig` through action config → `run` → core `ReviewRequest` → harness `HarnessContext`, plus the `@loupe` chat/fix paths.
- `action.yml` input defaults, example workflow, `examples/.loupe.json`, README.
- New test for the whip-config materialization.
- `task check` green (format + lint + tsc + 38 tests).

Follow-up (separate PRs, after this releases): simplify the monorepo/charts/quant/whip workflows to the Variant-D shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)