### PR TITLE
feat: visible failure comments on chat commands + configurable max-turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Key flags (defaults in parens): `--harness` (whip), `--model` (kimi-k3),
 `--reasoning low|medium|high` (low), `--profile quiet|chill|assertive` (chill),
 `--config <path>` (focused reviewers), `--reviewer <name>` (run just one),
 `--prompt-file <path>` (custom guidance), `--dir` (subdir scope), `--ensemble`
-(multi-model majority), `--timezone`, `--no-verify`, `--no-agentic`,
+(multi-model majority), `--timezone`, `--max-turns` (agentic loop cap),
+`--no-verify`, `--no-agentic`,
 `--providers env,dotenv,infisical`, `--dry-run`.
 
 Use `--dry-run` (with `LOG_LEVEL=debug` to see raw harness output) to compute and
@@ -111,8 +112,9 @@ Per-reviewer keys: `prompt`/`promptFile`, `include`/`exclude`, `model`,
 ### Top-level config — keep review policy out of the workflow
 
 The config file also carries the **review defaults** that used to be repeated in
-every workflow file: `harness`, `model`, `reasoning`, `profile`, `timezone`, and
-`dir`. Precedence is **Action input / CLI flag → `.loupe.json` → built-in
+every workflow file: `harness`, `model`, `reasoning`, `profile`, `timezone`,
+`dir`, and `maxTurns` (the agentic tool-loop cap; also per-reviewer). Precedence
+is **Action input / CLI flag → `.loupe.json` → built-in
 default**, so a workflow can still override, but by default the policy lives with
 the repo.
 

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
     description: "Timezone label for the review environment line (e.g. PST). Overrides .loupe.json; default UTC."
     required: false
     default: ""
+  max-turns:
+    description: "Cap on the agentic tool loop. Overrides .loupe.json; default 40."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -99,4 +103,5 @@ runs:
         LOUPE_ENSEMBLE: ${{ inputs.ensemble }}
         LOUPE_SKILLS: ${{ inputs.skills }}
         LOUPE_TIMEZONE: ${{ inputs.timezone }}
+        LOUPE_MAX_TURNS: ${{ inputs.max-turns }}
       run: bun run packages/action/src/main.ts

--- a/packages/action/src/cli.ts
+++ b/packages/action/src/cli.ts
@@ -116,6 +116,12 @@ program
     "--skills <paths>",
     "comma-separated skill paths (SKILL.md or skill dir) to fold into the reviewer",
   )
+  .option("--max-turns <n>", "cap the agentic tool loop (default 40)", (v) => {
+    const n = Number(v);
+    if (!Number.isInteger(n) || n <= 0)
+      throw new Error(`Invalid --max-turns "${v}". Use a positive integer.`);
+    return n;
+  })
   .option("--no-verify", "skip the second-opinion verification pass")
   .option(
     "--full",
@@ -143,6 +149,7 @@ program
         agentic: boolean;
         profile?: string;
         timezone?: string;
+        maxTurns?: number;
         ensemble?: string;
         skills?: string;
         verify: boolean;
@@ -168,6 +175,7 @@ program
         );
         const timezone = opts.timezone ?? settings.timezone ?? "UTC";
         const subdir = opts.dir ?? settings.dir;
+        const maxTurns = opts.maxTurns ?? settings.maxTurns;
         const ensembleModels = opts.ensemble
           ? opts.ensemble
               .split(",")
@@ -202,6 +210,7 @@ program
           ensembleModels,
           skills,
           timezone,
+          maxTurns,
           whipConfig: settings.whip,
         };
 
@@ -232,6 +241,7 @@ program
               pathInstructions: r.pathInstructions,
               ensembleModels: r.ensemble ?? ensembleModels,
               skills: r.skills ?? skills,
+              maxTurns: r.maxTurns ?? maxTurns,
               logger,
             });
             logger.info(`[${r.name}] ${formatResult(result)}`);

--- a/packages/action/src/config.ts
+++ b/packages/action/src/config.ts
@@ -57,7 +57,17 @@ const envSchema = z.object({
   LOUPE_ENSEMBLE: z.string().default(""),
   LOUPE_SKILLS: z.string().default(""),
   LOUPE_TIMEZONE: optionalInput,
+  LOUPE_MAX_TURNS: optionalInput,
 });
+
+function asMaxTurns(v: string | undefined): number | undefined {
+  if (v === undefined) return undefined;
+  const n = Number(v);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid max-turns "${v}". Use a positive integer.`);
+  }
+  return n;
+}
 
 const REASONING = ["low", "medium", "high"] as const;
 const PROFILES = ["quiet", "chill", "assertive"] as const;
@@ -96,6 +106,7 @@ export type Config = {
   readonly skills: readonly string[];
   readonly timezone: string;
   readonly whipConfig?: WhipConfig;
+  readonly maxTurns?: number;
   readonly eventName?: string;
   readonly eventPath?: string;
 };
@@ -144,6 +155,7 @@ export function loadConfig(): Config {
       .map((s) => s.trim())
       .filter(Boolean),
     timezone: env.LOUPE_TIMEZONE ?? file.timezone ?? "UTC",
+    maxTurns: asMaxTurns(env.LOUPE_MAX_TURNS) ?? file.maxTurns,
     whipConfig: file.whip,
     eventName: env.GITHUB_EVENT_NAME,
     eventPath: env.GITHUB_EVENT_PATH,

--- a/packages/action/src/orchestrate.ts
+++ b/packages/action/src/orchestrate.ts
@@ -28,6 +28,7 @@ export async function runReviews(
     subdir: config.subdir,
     verify: config.verify,
     whipConfig: config.whipConfig,
+    maxTurns: config.maxTurns,
     full,
   };
 
@@ -57,6 +58,7 @@ export async function runReviews(
           (config.ensembleModels.length ? config.ensembleModels : undefined),
         skills: [...new Set([...(r.skills ?? []), ...config.skills])],
         timezone: config.timezone,
+        maxTurns: r.maxTurns ?? config.maxTurns,
         logger,
       });
       logger.info(`[${r.name}] ${formatResult(result)}`);

--- a/packages/action/src/respond.ts
+++ b/packages/action/src/respond.ts
@@ -22,6 +22,27 @@ import { runReviews } from "./orchestrate";
 
 const MENTION = /@loupe\b/i;
 
+/**
+ * Post a visible failure comment so a command that throws after its ack never
+ * reads as silence. The full stack lives in the Actions run logs; the comment
+ * carries the short reason so a maintainer knows it errored (and where to look).
+ */
+async function postFailure(
+  octokit: Octokit,
+  ref: PullRef,
+  what: string,
+  err: unknown,
+  logger: Logger,
+): Promise<void> {
+  const reason = err instanceof Error ? err.message : String(err);
+  logger.error(`Chat command failed: ${what}`, { error: reason });
+  await postIssueComment(
+    octokit,
+    ref,
+    `⚠️ I couldn't complete the ${what} — ${reason.slice(0, 500)}\n\nSee the Actions run logs for details.`,
+  );
+}
+
 const HELP = `**loupe commands** (mention \`@loupe\`):
 - \`@loupe review\` — re-review the whole PR now.
 - \`@loupe fix <what to change>\` — make the change and push a commit to this PR.
@@ -76,6 +97,7 @@ async function runFix(
     workdir: cwd,
     env,
     whipConfig: config.whipConfig,
+    maxTurns: config.maxTurns,
     logger,
   });
 
@@ -156,7 +178,11 @@ export async function handleComment(
   if (/^(full\s+)?review\b/i.test(instruction)) {
     logger.info("Chat command: review");
     await postIssueComment(octokit, ref, "🔍 On it — re-reviewing this PR.");
-    await runReviews(config, logger, true);
+    try {
+      await runReviews(config, logger, true);
+    } catch (err) {
+      await postFailure(octokit, ref, "review", err, logger);
+    }
     return;
   }
 
@@ -164,34 +190,43 @@ export async function handleComment(
   if (fixMatch) {
     logger.info("Chat command: fix");
     await postIssueComment(octokit, ref, "🔧 On it — working on a fix.");
-    await runFix(
-      config,
-      octokit,
-      ref,
-      fixMatch[1]?.trim() || instruction,
-      logger,
-    );
+    try {
+      await runFix(
+        config,
+        octokit,
+        ref,
+        fixMatch[1]?.trim() || instruction,
+        logger,
+      );
+    } catch (err) {
+      await postFailure(octokit, ref, "fix", err, logger);
+    }
     return;
   }
 
   // Free-form question → answer from the diff.
   logger.info("Chat question", { chars: instruction.length });
-  const harness = getHarness(config.harnessName);
-  const env = await resolveCredentials(
-    harness.credentialKeys,
-    config.providers,
-  );
-  const pull = await fetchPullContext(octokit, ref);
-  const stdout = await harness.review({
-    systemPrompt: buildChatSystemPrompt(),
-    userPrompt: buildChatUserPrompt(instruction, pull.files),
-    model: config.model,
-    agentic: false,
-    workdir: config.workdir,
-    env,
-    whipConfig: config.whipConfig,
-    logger,
-  });
-  const answer = stdout.trim() || "I couldn't produce an answer for that.";
-  await postIssueComment(octokit, ref, answer);
+  try {
+    const harness = getHarness(config.harnessName);
+    const env = await resolveCredentials(
+      harness.credentialKeys,
+      config.providers,
+    );
+    const pull = await fetchPullContext(octokit, ref);
+    const stdout = await harness.review({
+      systemPrompt: buildChatSystemPrompt(),
+      userPrompt: buildChatUserPrompt(instruction, pull.files),
+      model: config.model,
+      agentic: false,
+      workdir: config.workdir,
+      env,
+      whipConfig: config.whipConfig,
+      maxTurns: config.maxTurns,
+      logger,
+    });
+    const answer = stdout.trim() || "I couldn't produce an answer for that.";
+    await postIssueComment(octokit, ref, answer);
+  } catch (err) {
+    await postFailure(octokit, ref, "answer", err, logger);
+  }
 }

--- a/packages/action/src/reviewers.ts
+++ b/packages/action/src/reviewers.ts
@@ -36,6 +36,8 @@ const reviewerSchema = z
     ensemble: z.array(z.string()).optional(),
     /** Skill docs (paths to SKILL.md or a skill dir) to fold into the reviewer. */
     skills: z.array(z.string()).optional(),
+    /** Cap on the agentic tool loop for this reviewer (default 40). */
+    maxTurns: z.number().int().positive().optional(),
   })
   .refine((r) => !(r.prompt && r.promptFile), {
     message: "reviewer has both prompt and promptFile; use one",
@@ -68,6 +70,7 @@ const configSchema = z.object({
   profile: z.enum(["quiet", "chill", "assertive"]).optional(),
   timezone: z.string().optional(),
   dir: z.string().optional(),
+  maxTurns: z.number().int().positive().optional(),
   whip: whipConfigSchema.optional(),
 });
 
@@ -80,6 +83,7 @@ export type LoupeSettings = {
   readonly profile?: Profile;
   readonly timezone?: string;
   readonly dir?: string;
+  readonly maxTurns?: number;
   readonly whip?: z.infer<typeof whipConfigSchema>;
 };
 
@@ -94,6 +98,7 @@ export function loadSettings(configPath: string): LoupeSettings {
     profile: c.profile,
     timezone: c.timezone,
     dir: c.dir,
+    maxTurns: c.maxTurns,
     whip: c.whip,
   };
 }
@@ -111,6 +116,7 @@ export type Reviewer = {
   readonly pathInstructions?: readonly { glob: string; instruction: string }[];
   readonly ensemble?: readonly string[];
   readonly skills?: readonly string[];
+  readonly maxTurns?: number;
 };
 
 /**
@@ -141,5 +147,6 @@ export function loadReviewers(configPath: string): Reviewer[] {
     ensemble: r.ensemble,
     // Top-level skills apply to every reviewer, plus any reviewer-specific ones.
     skills: [...new Set([...topSkills, ...(r.skills ?? [])])],
+    maxTurns: r.maxTurns,
   }));
 }

--- a/packages/action/src/run.ts
+++ b/packages/action/src/run.ts
@@ -37,6 +37,7 @@ export type RunInput = {
   readonly skills?: readonly string[];
   readonly timezone?: string;
   readonly whipConfig?: WhipConfig;
+  readonly maxTurns?: number;
   readonly logger: Logger;
 };
 
@@ -95,6 +96,7 @@ export async function reviewPullRequest(
     ensembleModels: input.ensembleModels,
     skills: input.skills,
     timezone: input.timezone,
+    maxTurns: input.maxTurns,
     logger,
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,8 @@ export type ReviewRequest = {
   readonly skills?: readonly string[];
   /** Timezone label for the review's environment line (e.g. "PST"). */
   readonly timezone?: string;
+  /** Cap on the agentic tool loop passed to the harness (default 40). */
+  readonly maxTurns?: number;
   readonly logger: Logger;
 };
 
@@ -291,6 +293,7 @@ export async function runReview(req: ReviewRequest): Promise<ReviewResult> {
         workdir: harnessCwd,
         env: req.harnessEnv,
         whipConfig: req.whipConfig,
+        maxTurns: req.maxTurns,
         logger,
       });
     let stdout: string;
@@ -428,6 +431,7 @@ async function verifyInline(
       workdir: harnessCwd,
       env: req.harnessEnv,
       whipConfig: req.whipConfig,
+      maxTurns: req.maxTurns,
       logger: req.logger,
     });
     const verdicts = parseVerification(stdout);

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -45,6 +45,8 @@ export type HarnessContext = {
   readonly env: Record<string, string>;
   /** whip provider/model catalog to materialize into a throwaway WHIP_HOME. */
   readonly whipConfig?: WhipConfig;
+  /** Cap on the agentic tool loop; harness default (40) when unset. */
+  readonly maxTurns?: number;
   readonly logger: Logger;
 };
 
@@ -287,7 +289,8 @@ export function whipHarness(): Harness {
     review: (ctx) => {
       // Agentic reviews need room to explore the checkout with tools; headless
       // diff-only reviews should answer in one turn, capped as a safety net.
-      const maxTurns = ctx.agentic ? "40" : "10";
+      // The agentic cap is configurable (config.json maxTurns / --max-turns).
+      const maxTurns = ctx.agentic ? String(ctx.maxTurns ?? 40) : "10";
       const args = [
         "run",
         "--format",


### PR DESCRIPTION
Prompted by a quant \`@loupe review\` that produced no output (whip exhausted its turns without emitting a final review) and left only silence after the "On it" ack.

## 1. Failure visibility (chat path)
\`handleComment\` now wraps the review/fix/question handlers and posts a visible **\`⚠️ I couldn't complete the <command> — <reason>\`** comment on error, pointing at the run logs. A failed command is no longer indistinguishable from "nothing happened."

## 2. Configurable max-turns
The whip agentic tool-loop cap (hardcoded 40) is now configurable via:
- \`.loupe.json\` top-level \`maxTurns\`, or **per-reviewer** \`maxTurns\`
- the \`max-turns\` Action input
- \`--max-turns <n>\` on the CLI

Precedence: flag/input → \`.loupe.json\` → built-in default (40). Headless one-shot stays at 1 turn. Threaded config → run → core → harness (+ the chat/fix paths).

\`task check\` green (format + lint + tsc + 38 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)