### PR TITLE
change default agentic max-turns from 40 to 10

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     required: false
     default: ""
   max-turns:
-    description: "Cap on the agentic tool loop. Overrides .loupe.json; default 40."
+    description: "Cap on the agentic tool loop. Overrides .loupe.json; default 10."
     required: false
     default: ""
 runs:

--- a/packages/action/src/cli.ts
+++ b/packages/action/src/cli.ts
@@ -116,7 +116,7 @@ program
     "--skills <paths>",
     "comma-separated skill paths (SKILL.md or skill dir) to fold into the reviewer",
   )
-  .option("--max-turns <n>", "cap the agentic tool loop (default 40)", (v) => {
+  .option("--max-turns <n>", "cap the agentic tool loop (default 10)", (v) => {
     const n = Number(v);
     if (!Number.isInteger(n) || n <= 0)
       throw new Error(`Invalid --max-turns "${v}". Use a positive integer.`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,7 +93,7 @@ export type ReviewRequest = {
   readonly skills?: readonly string[];
   /** Timezone label for the review's environment line (e.g. "PST"). */
   readonly timezone?: string;
-  /** Cap on the agentic tool loop passed to the harness (default 40). */
+  /** Cap on the agentic tool loop passed to the harness (default 10). */
   readonly maxTurns?: number;
   readonly logger: Logger;
 };

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -45,7 +45,7 @@ export type HarnessContext = {
   readonly env: Record<string, string>;
   /** whip provider/model catalog to materialize into a throwaway WHIP_HOME. */
   readonly whipConfig?: WhipConfig;
-  /** Cap on the agentic tool loop; harness default (40) when unset. */
+  /** Cap on the agentic tool loop; harness default (10) when unset. */
   readonly maxTurns?: number;
   readonly logger: Logger;
 };
@@ -290,7 +290,7 @@ export function whipHarness(): Harness {
       // Agentic reviews need room to explore the checkout with tools; headless
       // diff-only reviews should answer in one turn, capped as a safety net.
       // The agentic cap is configurable (config.json maxTurns / --max-turns).
-      const maxTurns = ctx.agentic ? String(ctx.maxTurns ?? 40) : "10";
+      const maxTurns = ctx.agentic ? String(ctx.maxTurns ?? 10) : "10";
       const args = [
         "run",
         "--format",


### PR DESCRIPTION
Lowers the built-in agentic tool-loop cap from **40 → 10**. With whip's finalize-on-max-turns (v0.5.4) forcing a final response at the cap, a tighter default keeps reviews fast and still produces output. Override per repo/reviewer via `maxTurns` in `.loupe.json`, the `max-turns` input, or `--max-turns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)