### PR TITLE
perf: run reviewers concurrently instead of sequentially

### DIFF
--- a/packages/action/src/orchestrate.ts
+++ b/packages/action/src/orchestrate.ts
@@ -38,28 +38,32 @@ export async function runReviews(
     logger.info("Running reviewers", {
       reviewers: reviewers.map((r) => r.name),
     });
-    for (const r of reviewers) {
-      const result = await reviewPullRequest({
-        ...base,
-        reviewerName: r.name,
-        guidance: r.guidance,
-        include: r.include,
-        exclude: r.exclude,
-        agentic: r.agentic,
-        model: r.model ?? config.model,
-        reasoning: r.reasoning ?? config.reasoning,
-        profile: r.profile ?? config.profile,
-        verify: r.verify ?? config.verify,
-        pathInstructions: r.pathInstructions,
-        ensembleModels:
-          r.ensemble ??
-          (config.ensembleModels.length ? config.ensembleModels : undefined),
-        skills: [...new Set([...(r.skills ?? []), ...config.skills])],
-        timezone: config.timezone,
-        logger,
-      });
-      logger.info(`[${r.name}] ${formatResult(result)}`);
-    }
+    // Reviewers are independent (each posts its own labeled review), so run them
+    // concurrently — wall-clock becomes the slowest reviewer, not their sum.
+    await Promise.all(
+      reviewers.map(async (r) => {
+        const result = await reviewPullRequest({
+          ...base,
+          reviewerName: r.name,
+          guidance: r.guidance,
+          include: r.include,
+          exclude: r.exclude,
+          agentic: r.agentic,
+          model: r.model ?? config.model,
+          reasoning: r.reasoning ?? config.reasoning,
+          profile: r.profile ?? config.profile,
+          verify: r.verify ?? config.verify,
+          pathInstructions: r.pathInstructions,
+          ensembleModels:
+            r.ensemble ??
+            (config.ensembleModels.length ? config.ensembleModels : undefined),
+          skills: [...new Set([...(r.skills ?? []), ...config.skills])],
+          timezone: config.timezone,
+          logger,
+        });
+        logger.info(`[${r.name}] ${formatResult(result)}`);
+      }),
+    );
     return;
   }
 


### PR DESCRIPTION
## Why

Reviewer profiles in `.loupe/config.json` are independent — each fetches its own PR context, runs its own harness, and posts its own labeled review. The orchestrator ran them in a sequential `for`/`await` loop, so a PR's review wall-clock was the **sum** of every reviewer.

For the inference monorepo (`code` over the whole diff + `migrations` on SQL files), that meant the slow agentic `code` reviewer and the high-reasoning `migrations` reviewer stacked back-to-back.

## What changed

`runReviews` now runs reviewers with `Promise.all` instead of a sequential loop. Wall-clock becomes the **slowest single reviewer**, not the sum.

No change to findings, parsing, validation, or what gets posted — each reviewer still produces and posts its own labeled review independently.

## Verification

`bun run check` — format, lint (type-aware), tsc build, and all 34 vitest tests pass.