### PR TITLE
feat: agentic reviews explore the diff (tree, not inline) + stable cache key

### DIFF
--- a/.github/workflows/loupe-chat.yml
+++ b/.github/workflows/loupe-chat.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.4"
+  WHIP_VERSION: "v0.5.5"
 
 jobs:
   chat:

--- a/.github/workflows/loupe-review.yml
+++ b/.github/workflows/loupe-review.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.4"
+  WHIP_VERSION: "v0.5.5"
 
 jobs:
   loupe:

--- a/packages/action/src/respond.ts
+++ b/packages/action/src/respond.ts
@@ -98,6 +98,7 @@ async function runFix(
     env,
     whipConfig: config.whipConfig,
     maxTurns: config.maxTurns,
+    cacheKey: `loupe/${config.owner}/${config.repo}/fix`,
     logger,
   });
 
@@ -222,6 +223,7 @@ export async function handleComment(
       env,
       whipConfig: config.whipConfig,
       maxTurns: config.maxTurns,
+      cacheKey: `loupe/${config.owner}/${config.repo}/chat`,
       logger,
     });
     const answer = stdout.trim() || "I couldn't produce an answer for that.";

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -39,6 +39,39 @@ export function commentableLines(
   return map;
 }
 
+/** Count added / removed lines in a patch (diff `+`/`-` lines, not hunk headers). */
+function patchStats(patch: string | undefined): {
+  added: number;
+  removed: number;
+} {
+  let added = 0;
+  let removed = 0;
+  if (!patch) return { added, removed };
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) added += 1;
+    else if (line.startsWith("-") && !line.startsWith("---")) removed += 1;
+  }
+  return { added, removed };
+}
+
+/**
+ * A compact tree of just the changed files with their line counts — what an
+ * AGENTIC reviewer gets instead of the full inline diff. The agent then reads
+ * each file's hunks (and the surrounding code) with its own tools, so a large
+ * PR's diff isn't re-sent in every turn's prompt.
+ */
+export function renderFileTree(files: readonly DiffFile[]): string {
+  return files
+    .map((f) => {
+      const { added, removed } = patchStats(f.patch);
+      const counts = f.patch
+        ? ` (+${added} −${removed})`
+        : " (binary/too large)";
+      return `- ${f.path}${counts}`;
+    })
+    .join("\n");
+}
+
 /** Compact text of the diff for the prompt: path headers + patches. */
 export function renderDiff(files: readonly DiffFile[]): string {
   return files

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,11 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { Harness, WhipConfig } from "@loupe/harness";
@@ -28,7 +35,24 @@ import {
   buildVerifyUserPrompt,
   type ReasoningEffort,
 } from "./prompt";
+import { renderDiff, type DiffFile } from "./diff";
 import { validateFindings } from "./validate";
+
+/**
+ * Write the full unified diff to a throwaway temp file and return its path, so
+ * an agentic review can read hunks from it on demand instead of carrying the
+ * whole diff inline in every turn's prompt.
+ */
+function writeDiffFile(files: readonly DiffFile[], logger: Logger): string {
+  const dir = mkdtempSync(join(tmpdir(), "loupe-diff-"));
+  const path = join(dir, "pr.diff");
+  writeFileSync(path, renderDiff(files));
+  logger.debug("Wrote diff file for agentic exploration", {
+    path,
+    files: files.length,
+  });
+  return path;
+}
 
 export * from "./types";
 export * from "./diff";
@@ -232,14 +256,6 @@ export async function runReview(req: ReviewRequest): Promise<ReviewResult> {
     skills,
     conventions: conventions.text,
   });
-  const userPrompt = buildUserPrompt({
-    title: pull.title,
-    description: pull.description,
-    files,
-    pathInstructions,
-    timezone: req.timezone,
-  });
-
   // The harness runs where the repo is checked out. Scope to the subdir only if
   // it actually exists on disk; fall back to the workdir (or cwd) so a run
   // without a local checkout — the whole diff is in the prompt — still spawns.
@@ -256,6 +272,27 @@ export async function runReview(req: ReviewRequest): Promise<ReviewResult> {
       { scoped, fallbackCwd: harnessCwd },
     );
   }
+
+  // Agentic reviews with a real checkout get a changed-file TREE plus a diff
+  // file to explore — so the (often huge) diff isn't inlined into every turn.
+  // Headless reviews (and agentic with no checkout) inline the full diff.
+  const treeMode = agentic && existsSync(scoped);
+  const diffPath = treeMode ? writeDiffFile(files, logger) : undefined;
+  const commonPrompt = {
+    title: pull.title,
+    description: pull.description,
+    files,
+    pathInstructions,
+    timezone: req.timezone,
+  };
+  const headlessUserPrompt = buildUserPrompt(commonPrompt);
+  const agenticUserPrompt = diffPath
+    ? buildUserPrompt({ ...commonPrompt, diffPath })
+    : headlessUserPrompt;
+
+  // Stable prompt-cache key per repo+reviewer so whip reuses the cached system
+  // prefix across runs (and its own turns within a run).
+  const cacheKey = `loupe/${req.ref.owner}/${req.ref.repo}/${req.reviewerName ?? "default"}`;
 
   // Noise profile: hard-filter by severity (the prompt asks too, this enforces).
   const keep = new Set(severitiesForProfile(profile));
@@ -287,13 +324,14 @@ export async function runReview(req: ReviewRequest): Promise<ReviewResult> {
               skills,
               conventions: conventions.text,
             }),
-        userPrompt,
+        userPrompt: useAgentic ? agenticUserPrompt : headlessUserPrompt,
         model,
         agentic: useAgentic,
         workdir: harnessCwd,
         env: req.harnessEnv,
         whipConfig: req.whipConfig,
         maxTurns: req.maxTurns,
+        cacheKey,
         logger,
       });
     let stdout: string;
@@ -432,6 +470,7 @@ async function verifyInline(
       env: req.harnessEnv,
       whipConfig: req.whipConfig,
       maxTurns: req.maxTurns,
+      cacheKey: `loupe/${req.ref.owner}/${req.ref.repo}/${req.reviewerName ?? "default"}/verify`,
       logger: req.logger,
     });
     const verdicts = parseVerification(stdout);

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,4 +1,4 @@
-import { renderDiff, type DiffFile } from "./diff";
+import { renderDiff, renderFileTree, type DiffFile } from "./diff";
 import type { Finding, Profile } from "./types";
 
 export type ReasoningEffort = "low" | "medium" | "high";
@@ -94,10 +94,14 @@ review on the diff in the user message.`.trim();
 
 const AGENTIC_DIRECTIVE = `
 You HAVE repository access: the full checkout is your working directory and you
-may use your tools to read files. Use them deliberately to assess real-world
-impact — inspect the actual schema/table definitions, related migrations, model
-and query code, and existing indexes/constraints the diff interacts with. Ground
-each finding in what you actually found in the codebase, not just the diff.
+may use your tools to read files. The user message gives you the LIST of changed
+files (not the full diff) and the path to a file holding the complete diff —
+read each changed file's hunks from there on demand, then inspect the
+surrounding code. Investigate only what the change touches; do not slurp the
+whole diff or unrelated files into context. Use your tools deliberately to
+assess real-world impact — the actual schema/table definitions, related
+migrations, model and query code, and existing indexes/constraints the diff
+interacts with. Ground each finding in what you actually found, not a guess.
 
 Use SUBAGENTS heavily. Fan out independent investigations in parallel — one
 subagent per file, per suspected issue, or per question — instead of exploring
@@ -195,23 +199,39 @@ export type UserPromptInput = {
   readonly pathInstructions?: readonly string[];
   /** Timezone label for the environment line (e.g. "PST"). */
   readonly timezone?: string;
+  /**
+   * Absolute path to a file holding the full unified diff. When set (agentic
+   * reviews with a real checkout), the message carries only the changed-file
+   * TREE and points the agent at this file to read hunks on demand — the diff
+   * is not inlined, so it isn't re-sent in every turn. Omit for headless
+   * reviews, where the full diff must be inlined.
+   */
+  readonly diffPath?: string;
 };
 
-/** The per-PR user message: environment, metadata, per-path notes, and the diff.
- * Repo conventions live in the system prompt (stable/cacheable), not here. */
+/** The per-PR user message: environment, metadata, per-path notes, and either
+ * the full inline diff (headless) or a changed-file tree + a pointer to the
+ * diff file the agent reads on demand (agentic). Repo conventions live in the
+ * system prompt (stable/cacheable), not here. */
 export function buildUserPrompt(input: UserPromptInput): string {
   const pathNotes = input.pathInstructions?.length
     ? `Extra instructions for some of the changed files:\n${input.pathInstructions
         .map((i) => `- ${i}`)
         .join("\n")}`
     : "";
+  const diffSection = input.diffPath
+    ? [
+        "Changed files (the full diff is NOT inlined — explore it yourself):",
+        renderFileTree(input.files),
+        `The complete unified diff is written to \`${input.diffPath}\`. For each file you review, read its hunks from that file (e.g. with grep/sed by the \`### <path>\` header) and inspect the surrounding code in the checkout. Read only what the change touches — do not read the whole diff up front.`,
+      ].join("\n\n")
+    : ["Diff under review:", renderDiff(input.files)].join("\n\n");
   return [
     environmentLine(input.timezone),
     `PR title: ${input.title}`,
     input.description ? `PR description:\n${input.description}` : "",
     pathNotes,
-    "Diff under review:",
-    renderDiff(input.files),
+    diffSection,
   ]
     .filter(Boolean)
     .join("\n\n");

--- a/packages/core/tests/prompt.test.ts
+++ b/packages/core/tests/prompt.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFileTree, type DiffFile } from "../src/diff";
+import { buildUserPrompt } from "../src/prompt";
+
+const files: DiffFile[] = [
+  { path: "src/a.ts", patch: "@@ -1,1 +1,2 @@\n line\n+added line\n-removed" },
+  { path: "img.png", patch: undefined },
+];
+
+describe("renderFileTree", () => {
+  it("lists paths with +/- counts, and marks binaries", () => {
+    const tree = renderFileTree(files);
+    expect(tree).toContain("- src/a.ts (+1 −1)");
+    expect(tree).toContain("- img.png (binary/too large)");
+    // it must NOT contain the actual patch body
+    expect(tree).not.toContain("added line");
+  });
+});
+
+describe("buildUserPrompt", () => {
+  const base = { title: "t", description: "", files };
+
+  it("headless mode inlines the full diff", () => {
+    const p = buildUserPrompt(base);
+    expect(p).toContain("Diff under review:");
+    expect(p).toContain("+added line"); // the patch body is present
+    expect(p).not.toContain("is written to");
+  });
+
+  it("agentic mode (diffPath) sends the tree + a pointer, not the diff body", () => {
+    const p = buildUserPrompt({ ...base, diffPath: "/tmp/x/pr.diff" });
+    expect(p).toContain("Changed files");
+    expect(p).toContain("- src/a.ts (+1 −1)");
+    expect(p).toContain("/tmp/x/pr.diff");
+    expect(p).not.toContain("+added line"); // the diff body is NOT inlined
+  });
+});

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -47,6 +47,9 @@ export type HarnessContext = {
   readonly whipConfig?: WhipConfig;
   /** Cap on the agentic tool loop; harness default (10) when unset. */
   readonly maxTurns?: number;
+  /** Stable prompt-cache key (e.g. repo/reviewer) so the provider reuses the
+   * cached system prefix across runs. Passed to whip as -cache-key. */
+  readonly cacheKey?: string;
   readonly logger: Logger;
 };
 
@@ -303,6 +306,8 @@ export function whipHarness(): Harness {
         ctx.systemPrompt,
       ];
       if (ctx.model) args.push("-m", ctx.model);
+      // Stable cache key → the provider reuses the cached prefix across runs.
+      if (ctx.cacheKey) args.push("-cache-key", ctx.cacheKey);
       const whipEnv = ctx.whipConfig ? materializeWhipHome(ctx.whipConfig) : {};
       return runWhipStreaming(args, {
         ...ctx,


### PR DESCRIPTION
Profiling loupe's usage: **~250k input tokens per agentic turn, `cachedInputTokens=0`** — the whole PR diff was piped into every turn, uncached. Two fixes:

## 1. Agentic reviews explore the diff instead of receiving it inline
The user message now carries a **changed-file tree** (`path (+A −D)`) instead of the full diff. The complete diff is written to a temp file, and the agent reads each file's hunks (and the surrounding code) **on demand** — so a large PR's diff isn't re-sent in every turn. The agentic directive tells it to investigate only what the change touches. **Headless** reviews (and agentic runs with no checkout) still inline the full diff.

## 2. Stable prompt-cache key
loupe passes `-cache-key loupe/<owner>/<repo>/<reviewer>` to whip so the provider reuses the cached **system prefix across runs**. (Within-run caching comes free from whip v0.5.5's per-run key.) Threaded through core + the chat/fix paths.

> **Requires whip ≥ v0.5.5** for the `-cache-key` flag. Merge order: release whip v0.5.5 → bump `WHIP_VERSION` in consuming repos → then merge this + move `@v0`.

`task check` green (44 tests; adds `renderFileTree` + prompt tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)