### PR TITLE
fix(core): only delete or read back loupe's own marked comments

### DIFF
--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -54,6 +54,29 @@ export async function fetchPullContext(
   };
 }
 
+/** Login the workflow token posts as when `GET /user` is unavailable to it. */
+const ACTIONS_BOT_LOGIN = "github-actions[bot]";
+const selfLogins = new WeakMap<Octokit, Promise<string>>();
+
+/**
+ * The login loupe's own comments and reviews carry. A PAT or app user token
+ * answers `GET /user`; the default Actions token cannot, and posts as
+ * github-actions[bot]. Marker text alone is not proof of authorship: a human
+ * quoting loupe output carries the marker too, so every "is this mine" check
+ * pairs the marker with this login.
+ */
+export function getSelfLogin(octokit: Octokit): Promise<string> {
+  let cached = selfLogins.get(octokit);
+  if (!cached) {
+    cached = octokit.users
+      .getAuthenticated()
+      .then((r) => r.data.login)
+      .catch(() => ACTIONS_BOT_LOGIN);
+    selfLogins.set(octokit, cached);
+  }
+  return cached;
+}
+
 /**
  * The head SHA this reviewer last reviewed, read from the sha stamped in its
  * most recent review's marker. Undefined if it has never reviewed this PR.
@@ -65,12 +88,13 @@ export async function getLastReviewedSha(
 ): Promise<string | undefined> {
   const prefix = markerPrefix(reviewerName);
   try {
+    const self = await getSelfLogin(octokit);
     const reviews = await octokit.paginate(octokit.pulls.listReviews, {
       ...ref,
       per_page: 100,
     });
     for (const r of reviews.reverse()) {
-      if (r.body?.includes(prefix)) {
+      if (r.user?.login === self && r.body?.includes(prefix)) {
         const m = /sha=([0-9a-f]{7,40})/.exec(r.body);
         if (m) return m[1];
       }
@@ -163,9 +187,11 @@ function makeMarker(reviewerName: string | undefined, sha: string): string {
 
 /**
  * Delete this reviewer's inline comments from a previous run so re-reviews
- * replace rather than duplicate. When `refreshPaths` is given (incremental
- * review), only comments on those files are removed — comments on files
- * unchanged since the last review are kept. Best-effort: never blocks posting.
+ * replace rather than duplicate. Only comments posted under loupe's own login
+ * qualify; a human comment that quotes the marker is left alone. When
+ * `refreshPaths` is given (incremental review), only comments on those files
+ * are removed — comments on files unchanged since the last review are kept.
+ * Best-effort: never blocks posting.
  */
 async function deletePriorComments(
   octokit: Octokit,
@@ -176,6 +202,7 @@ async function deletePriorComments(
 ): Promise<void> {
   const prefix = markerPrefix(reviewerName);
   try {
+    const self = await getSelfLogin(octokit);
     const comments = await octokit.paginate(octokit.pulls.listReviewComments, {
       owner: ref.owner,
       repo: ref.repo,
@@ -184,7 +211,9 @@ async function deletePriorComments(
     });
     const mine = comments.filter(
       (c) =>
-        c.body.includes(prefix) && (!refreshPaths || refreshPaths.has(c.path)),
+        c.user?.login === self &&
+        c.body.includes(prefix) &&
+        (!refreshPaths || refreshPaths.has(c.path)),
     );
     for (const c of mine) {
       await octokit.pulls.deleteReviewComment({

--- a/packages/core/tests/github.test.ts
+++ b/packages/core/tests/github.test.ts
@@ -28,8 +28,10 @@ function fakeOctokit(opts: {
   const deleteReviewComment = vi.fn(async () => ({ data: {} }));
   const createReview = vi.fn(async () => ({ data: {} }));
   const octokit = {
-    paginate: async (fn: (p: unknown) => Promise<{ data: unknown }>, p: unknown) =>
-      (await fn(p)).data,
+    paginate: async (
+      fn: (p: unknown) => Promise<{ data: unknown }>,
+      p: unknown,
+    ) => (await fn(p)).data,
     pulls: {
       listReviewComments: async () => ({ data: opts.comments ?? [] }),
       listReviews: async () => ({ data: opts.reviews ?? [] }),
@@ -38,12 +40,17 @@ function fakeOctokit(opts: {
     },
     users: {
       getAuthenticated: async () => {
-        if (!opts.login) throw new Error("Resource not accessible by integration");
+        if (!opts.login)
+          throw new Error("Resource not accessible by integration");
         return { data: { login: opts.login } };
       },
     },
   };
-  return { octokit: octokit as unknown as Octokit, deleteReviewComment, createReview };
+  return {
+    octokit: octokit as unknown as Octokit,
+    deleteReviewComment,
+    createReview,
+  };
 }
 
 describe("postReview prior-comment cleanup", () => {
@@ -51,9 +58,24 @@ describe("postReview prior-comment cleanup", () => {
     const { octokit, deleteReviewComment } = fakeOctokit({
       login: "loupe-bot",
       comments: [
-        { id: 1, path: "a.ts", body: `finding\n\n${marker}`, user: { login: "loupe-bot" } },
-        { id: 2, path: "a.ts", body: `this one is real:\n${marker}`, user: { login: "alice" } },
-        { id: 3, path: "a.ts", body: "unrelated", user: { login: "loupe-bot" } },
+        {
+          id: 1,
+          path: "a.ts",
+          body: `finding\n\n${marker}`,
+          user: { login: "loupe-bot" },
+        },
+        {
+          id: 2,
+          path: "a.ts",
+          body: `this one is real:\n${marker}`,
+          user: { login: "alice" },
+        },
+        {
+          id: 3,
+          path: "a.ts",
+          body: "unrelated",
+          user: { login: "loupe-bot" },
+        },
       ],
     });
     await postReview(octokit, ref, emptyReview, [], [], silent, {
@@ -70,7 +92,12 @@ describe("postReview prior-comment cleanup", () => {
   it("falls back to github-actions[bot] when the token cannot call GET /user", async () => {
     const { octokit, deleteReviewComment } = fakeOctokit({
       comments: [
-        { id: 1, path: "a.ts", body: marker, user: { login: "github-actions[bot]" } },
+        {
+          id: 1,
+          path: "a.ts",
+          body: marker,
+          user: { login: "github-actions[bot]" },
+        },
         { id: 2, path: "a.ts", body: marker, user: { login: "alice" } },
       ],
     });
@@ -91,8 +118,14 @@ describe("getLastReviewedSha", () => {
     const { octokit } = fakeOctokit({
       login: "loupe-bot",
       reviews: [
-        { body: "<!-- loupe:bugs sha=1111111 -->", user: { login: "loupe-bot" } },
-        { body: "quoting: <!-- loupe:bugs sha=2222222 -->", user: { login: "alice" } },
+        {
+          body: "<!-- loupe:bugs sha=1111111 -->",
+          user: { login: "loupe-bot" },
+        },
+        {
+          body: "quoting: <!-- loupe:bugs sha=2222222 -->",
+          user: { login: "alice" },
+        },
       ],
     });
     expect(await getLastReviewedSha(octokit, ref, "bugs")).toBe("1111111");

--- a/packages/core/tests/github.test.ts
+++ b/packages/core/tests/github.test.ts
@@ -1,0 +1,100 @@
+import type { Octokit } from "@octokit/rest";
+import { describe, expect, it, vi } from "vitest";
+
+import { getLastReviewedSha, postReview } from "../src/github";
+import type { ReviewOutput } from "../src/types";
+
+const ref = { owner: "o", repo: "r", pull_number: 1 };
+const silent = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as never;
+const marker = "<!-- loupe:bugs sha=abc1234 -->";
+const emptyReview: ReviewOutput = {
+  summary: "s",
+  concerns: [],
+  highlights: [],
+  findings: [],
+} as unknown as ReviewOutput;
+
+/** Minimal Octokit double: paginate unwraps `data`, everything else is a spy. */
+function fakeOctokit(opts: {
+  login?: string;
+  comments?: unknown[];
+  reviews?: unknown[];
+}) {
+  const deleteReviewComment = vi.fn(async () => ({ data: {} }));
+  const createReview = vi.fn(async () => ({ data: {} }));
+  const octokit = {
+    paginate: async (fn: (p: unknown) => Promise<{ data: unknown }>, p: unknown) =>
+      (await fn(p)).data,
+    pulls: {
+      listReviewComments: async () => ({ data: opts.comments ?? [] }),
+      listReviews: async () => ({ data: opts.reviews ?? [] }),
+      deleteReviewComment,
+      createReview,
+    },
+    users: {
+      getAuthenticated: async () => {
+        if (!opts.login) throw new Error("Resource not accessible by integration");
+        return { data: { login: opts.login } };
+      },
+    },
+  };
+  return { octokit: octokit as unknown as Octokit, deleteReviewComment, createReview };
+}
+
+describe("postReview prior-comment cleanup", () => {
+  it("deletes only loupe's own marked comments, never a human quoting the marker", async () => {
+    const { octokit, deleteReviewComment } = fakeOctokit({
+      login: "loupe-bot",
+      comments: [
+        { id: 1, path: "a.ts", body: `finding\n\n${marker}`, user: { login: "loupe-bot" } },
+        { id: 2, path: "a.ts", body: `this one is real:\n${marker}`, user: { login: "alice" } },
+        { id: 3, path: "a.ts", body: "unrelated", user: { login: "loupe-bot" } },
+      ],
+    });
+    await postReview(octokit, ref, emptyReview, [], [], silent, {
+      reviewerName: "bugs",
+      headSha: "def5678",
+      fileCount: 1,
+    });
+    expect(deleteReviewComment).toHaveBeenCalledTimes(1);
+    expect(deleteReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 1 }),
+    );
+  });
+
+  it("falls back to github-actions[bot] when the token cannot call GET /user", async () => {
+    const { octokit, deleteReviewComment } = fakeOctokit({
+      comments: [
+        { id: 1, path: "a.ts", body: marker, user: { login: "github-actions[bot]" } },
+        { id: 2, path: "a.ts", body: marker, user: { login: "alice" } },
+      ],
+    });
+    await postReview(octokit, ref, emptyReview, [], [], silent, {
+      reviewerName: "bugs",
+      headSha: "def5678",
+      fileCount: 1,
+    });
+    expect(deleteReviewComment).toHaveBeenCalledTimes(1);
+    expect(deleteReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 1 }),
+    );
+  });
+});
+
+describe("getLastReviewedSha", () => {
+  it("ignores a human review that quotes the marker", async () => {
+    const { octokit } = fakeOctokit({
+      login: "loupe-bot",
+      reviews: [
+        { body: "<!-- loupe:bugs sha=1111111 -->", user: { login: "loupe-bot" } },
+        { body: "quoting: <!-- loupe:bugs sha=2222222 -->", user: { login: "alice" } },
+      ],
+    });
+    expect(await getLastReviewedSha(octokit, ref, "bugs")).toBe("1111111");
+  });
+});


### PR DESCRIPTION
## Summary

`deletePriorComments` and `getLastReviewedSha` identified loupe's own output by the `<!-- loupe:<reviewer> ` marker text alone. A human inline comment that quotes a loupe finding (marker included, which is what GitHub's "Quote reply" copies) was deleted on the next re-review, and a human review quoting a marker could set the incremental base sha.

This resolves the posting identity once per Octokit (`GET /user`, falling back to `github-actions[bot]` when the workflow token cannot call it) and requires that login alongside the marker in both places.

## Tests

`packages/core/tests/github.test.ts`:
- a marked human inline comment survives `postReview` while loupe's own marked comment is deleted
- the `github-actions[bot]` fallback applies when `GET /user` is unavailable
- `getLastReviewedSha` ignores a human review quoting the marker

`bun run check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub comment cleanup and incremental SHA detection; mis-identifying the bot login could leave stale comments or skip cleanup, but scope is limited to loupe's own PR review flow.
> 
> **Overview**
> Loupe used the `<!-- loupe:<reviewer>` marker alone to find its prior inline comments and last-reviewed SHA. **Quote-reply** comments from humans that include the same marker were wrongly deleted on re-review, and human reviews quoting a marker could skew incremental review bases.
> 
> This PR adds **`getSelfLogin`**, resolving the posting identity once per Octokit (`GET /user`, or **`github-actions[bot]`** when the workflow token cannot call it), and requires **marker + matching author login** in `deletePriorComments` and `getLastReviewedSha`.
> 
> New **`packages/core/tests/github.test.ts`** covers human-quoted markers, the Actions bot fallback, and SHA lookup ignoring non-loupe reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3c12e9f128d5e0fb59af0f3e94f7fa55a549bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->