### PR TITLE
chore(loupe): switch main review model to glm-5.3 (cost)

### DIFF
--- a/.loupe/config.json
+++ b/.loupe/config.json
@@ -1,6 +1,6 @@
 {
   "harness": "whip",
-  "model": "kimi-k3",
+  "model": "glm-5.3",
   "timezone": "PST",
   "maxTurns": 2,
   "whip": {
@@ -10,8 +10,9 @@
       "baseUrl": "https://api.inference.net/v1",
       "apiKeyEnv": "INFERENCE_API_KEY"
     },
-    "defaultModel": "kimi-k3",
+    "defaultModel": "glm-5.3",
     "models": [
+      "glm-5.3",
       "kimi-k3",
       "kimi-k3-fast",
       "glm-5.3-flash",


### PR DESCRIPTION
Switches the main review model from kimi-k3 to **glm-5.3** for all reviewers (kimi-k3 was ~76% of loupe spend and the priciest model). glm-5.3 is ~3-5× cheaper per token; caching + fewer turns already applied. Subagent/panel models unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)