### PR TITLE
ci(loupe): run loupe from main

### DIFF
--- a/.github/workflows/loupe-chat.yml
+++ b/.github/workflows/loupe-chat.yml
@@ -61,7 +61,7 @@ jobs:
           include-imports: true
       - name: Respond
         continue-on-error: true
-        uses: context-labs/loupe@v0
+        uses: context-labs/loupe@main
         with:
           config: .loupe/config.json
         env:

--- a/.github/workflows/loupe-review.yml
+++ b/.github/workflows/loupe-review.yml
@@ -58,7 +58,7 @@ jobs:
           include-imports: true
       - name: Review
         continue-on-error: true
-        uses: context-labs/loupe@v0
+        uses: context-labs/loupe@main
         with:
           config: .loupe/config.json
         env:


### PR DESCRIPTION
Run loupe from `main` instead of the `v0` tag, which had fallen 6 commits behind (in-place summary updates, author guard on comment cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)