### PR TITLE
docs: how loupe works (diagrams)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@ AI pull-request reviewer: inline, line-anchored comments with a
 COMMENT / REQUEST_CHANGES verdict. Harness-agnostic, reviews against each repo's
 own conventions, runs its focused reviewers agentically by default.
 
+## How it works
+
+Start at [how-it-works/README.md](how-it-works/README.md): triggers, the review pipeline, what the agent sees, the GitHub review and comment objects loupe creates and edits, first vs incremental runs, and `@loupe` chat. Mermaid diagrams throughout.
+
 ## User docs
 
 - [Guide](guide.md) — install, run a review locally, CLI flags, dry-run.

--- a/docs/how-it-works/README.md
+++ b/docs/how-it-works/README.md
@@ -1,0 +1,38 @@
+# How loupe works
+
+loupe is a GitHub Action that reviews pull requests with an agentic coding CLI (whip, claude, or codex). A repo declares one or more focused **reviewers** in a `.loupe.json`, each with its own prompt and file globs. loupe runs every reviewer whose globs match a changed file and posts inline comments plus one persistent summary comment per reviewer.
+
+Source: [context-labs/loupe](https://github.com/context-labs/loupe). loupe reviews its own PRs with [`.loupe/config.json`](../../.loupe/config.json).
+
+## Read in this order
+
+1. [Triggers](./triggers.md) — which GitHub events start a run, and what stops one. 2 min.
+2. [A review run](./review-run.md) — the pipeline from event to posted review. 5 min.
+3. [What the agent sees](./context.md) — system prompt, user prompt, skills, conventions, diff file. 4 min.
+4. [GitHub objects](./github-objects.md) — reviews, inline comments, the summary comment, markers, delete and update rules. 5 min.
+5. [First run vs later runs](./first-vs-incremental.md) — incremental review keyed on a SHA marker. 4 min.
+6. [@loupe chat](./chat.md) — `review`, `fix`, `help`, and free-form questions. 3 min.
+7. [Configuration](../configuration.md) — every knob in `.loupe.json`. Reference.
+
+## 30-second picture
+
+```mermaid
+flowchart LR
+    PR[PR event or @loupe comment] --> WF[GitHub Actions workflow]
+    WF --> A[loupe action]
+    A -->|REST| GH[(GitHub API)]
+    A -->|spawn| W[agent CLI]
+    W -->|tools| CO[repo checkout]
+    W -->|completions| LLM[model provider]
+    A -->|review + comments| GH
+```
+
+- **One job per PR event.** The recommended workflow groups concurrency by PR number so a new push cancels the in-flight review.
+- **Reviewers run in parallel** inside that job. Each one scopes to its globs, runs its own agent, and posts its own review and summary comment.
+- **The agent never talks to GitHub.** It reads the checkout and a diff file on disk and emits one JSON object. loupe's TypeScript owns every GitHub API call.
+- **Blockers request changes.** Everything else is a `COMMENT` review. loupe never approves.
+- **Advisory by design.** The recommended workflow runs with `continue-on-error: true` and is not a required check.
+
+## Pinning
+
+`uses: context-labs/loupe@main` runs the latest code. A tag or SHA pin freezes behavior, including the GitHub-object rules in these docs, at that point.

--- a/docs/how-it-works/chat.md
+++ b/docs/how-it-works/chat.md
@@ -61,7 +61,7 @@ sequenceDiagram
     alt head repo is a fork
         L->>GH: comment "can't push to a fork"
     else
-        L->>G: fetch origin <head>; checkout -B <head> FETCH_HEAD
+        L->>G: fetch origin <head>, then checkout -B <head> FETCH_HEAD
         L->>GH: pulls.listFiles
         L->>W: agentic, fix prompt + instruction + changed-file list
         W->>G: edit files

--- a/docs/how-it-works/chat.md
+++ b/docs/how-it-works/chat.md
@@ -1,0 +1,92 @@
+# @loupe chat
+
+
+Any PR comment containing `@loupe` (case-insensitive, word boundary) starts the chat job. Review-thread comments count too. The text after the mention is the instruction.
+
+## Dispatch
+
+```mermaid
+flowchart TD
+    B[comment body] --> M{contains @loupe?}
+    M -->|no| X[ignore]
+    M -->|yes| I[instruction = body minus mention]
+    I --> H{empty or starts with help}
+    H -->|yes| HELP[post help comment]
+    H -->|no| R{starts with review}
+    R -->|yes| ACK1[post 🔍 ack] --> RV[runReviews full = true]
+    R -->|no| F{starts with fix}
+    F -->|yes| ACK2[post 🔧 ack] --> FIX[runFix]
+    F -->|no| Q[free-form question]
+    RV -->|throws| ERR[post ⚠️ failure comment]
+    FIX -->|throws| ERR
+    Q -->|throws| ERR
+```
+
+Every reply is a top-level issue comment via `issues.createComment`. Chat never edits or deletes anything.
+
+## `@loupe review`
+
+Same pipeline as a push, with `full` forced. See [First run vs later runs](./first-vs-incremental.md#forced-full-run). All configured reviewers run.
+
+## `@loupe <question>`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as commenter
+    participant L as loupe
+    participant GH as GitHub API
+    participant W as agent
+    U->>GH: "@loupe is the retry loop safe?"
+    GH->>L: issue_comment event
+    L->>GH: pulls.get, pulls.listFiles
+    L->>W: headless, chat system prompt + question + full inline diff
+    W-->>L: prose answer
+    L->>GH: issues.createComment(answer)
+```
+
+Headless: no tools, no checkout access, whole PR diff inlined regardless of reviewer globs. No reviewer guidance, skills, or conventions are included. The answer is prose, not JSON.
+
+## `@loupe fix <what>`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant L as loupe
+    participant GH as GitHub API
+    participant G as git in checkout
+    participant W as agent
+    L->>GH: issues.createComment("🔧 On it")
+    L->>GH: pulls.get
+    alt head repo is a fork
+        L->>GH: comment "can't push to a fork"
+    else
+        L->>G: fetch origin <head>; checkout -B <head> FETCH_HEAD
+        L->>GH: pulls.listFiles
+        L->>W: agentic, fix prompt + instruction + changed-file list
+        W->>G: edit files
+        L->>G: status --porcelain
+        alt no changes
+            L->>GH: comment "didn't make any changes"
+        else
+            L->>G: commit as loupe, push HEAD:<head> with token
+            L->>GH: comment "✅ Pushed <sha>. Re-review with @loupe review"
+        end
+    end
+```
+
+- Commit message: `loupe: <first 60 chars of instruction>`. Author `loupe <loupe@users.noreply.github.com>`.
+- The push does **not** trigger a new review run. Pushes made with the Actions token do not fire `pull_request` workflows. Ask for `@loupe review` after.
+- A push rejected by branch protection posts a comment saying so. The chat job needs `contents: write`.
+
+## Failure comment
+
+Any thrown error after the ack posts:
+
+```
+⚠️ I couldn't complete the <review|fix|answer> — <first 500 chars of error>
+
+See the Actions run logs for details.
+```
+
+Next: [Configuration](../configuration.md) for every knob, or back to the [index](./README.md).

--- a/docs/how-it-works/context.md
+++ b/docs/how-it-works/context.md
@@ -1,0 +1,64 @@
+# What the agent sees
+
+
+The agent gets two messages and a working directory. Nothing else. It has no GitHub token and no PR URL.
+
+## Layout
+
+```mermaid
+flowchart LR
+    subgraph SYS["System prompt: stable per reviewer, prompt-cached"]
+        direction TB
+        G[Reviewer guidance: prompt or promptFile]
+        SK[Skills: SKILL.md bodies]
+        CV[Convention docs: CLAUDE.md, AGENTS.md, ...]
+        RN[Reasoning note: low / medium / high]
+        PD[Profile directive: quiet / chill / assertive]
+        AD[Tool directive: agentic or headless]
+        OC[Output contract: one JSON object]
+    end
+    subgraph USR["User message: per PR"]
+        direction TB
+        ENV[Environment line: date and time]
+        TI[PR title and description]
+        PI[pathInstructions matching changed files]
+        TR[Changed-file tree and path to pr.diff]
+    end
+    subgraph CWD["Working directory"]
+        CO[checkout, scoped to dir if set]
+        DF["/tmp/loupe-diff-*/pr.diff"]
+    end
+```
+
+## System prompt, in order
+
+Order matters for caching. Everything here is identical across PRs for a given reviewer, so the provider reuses the cached prefix. `-cache-key loupe/<owner>/<repo>/<reviewer>` names that prefix.
+
+1. **Guidance.** The reviewer's `prompt` or `promptFile`, verbatim. It replaces loupe's default guidance when set.
+2. **Skills.** Each path in `skills` is read from the checkout. A directory means its `SKILL.md`. A missing skill logs a warning and is skipped.
+3. **Conventions.** Every convention doc that exists at the PR head, concatenated under `# <path>` headers. Fetched via the GitHub API, not the checkout.
+4. **Reasoning note.** One sentence.
+5. **Profile directive.** Which severities to report.
+6. **Tool directive.** Agentic: you have the checkout, read hunks from the diff file on demand, fan out subagents, confirm suspected blockers with a panel of different models, then stop and emit JSON. Headless (verify pass, retry, chat): no tools, diff is inline.
+7. **Output contract.** One JSON object: `summary`, `concerns[]`, `highlights[]`, optional `diagram`, `findings[]` with `path`, `line` (new-file line, must be in the diff), `severity`, `body`.
+
+## User message
+
+- Environment line with the current date and time in the configured `timezone`.
+- PR title and body.
+- `pathInstructions` whose glob matches at least one in-scope file, one bullet each.
+- **Agentic:** a tree of changed files and the absolute path of `pr.diff`. The diff is not inlined so it is not re-sent on every turn.
+- **Headless:** the full rendered diff, `### <path>` then the unified patch.
+
+## What is in the diff file
+
+Only the files in scope for this reviewer and this run. On an incremental run that is the delta since the last reviewed SHA, not the whole PR. See [First run vs later runs](./first-vs-incremental.md).
+
+## What is not there
+
+- No GitHub credentials, PR number, or API access. The agent cannot post or read comments.
+- No prior loupe findings. Each run reviews fresh.
+- No files outside `dir` when it is set. The working directory is the subdir.
+- Severities outside the profile, even if emitted. The filter runs after parsing.
+
+Next: [GitHub objects](./github-objects.md).

--- a/docs/how-it-works/first-vs-incremental.md
+++ b/docs/how-it-works/first-vs-incremental.md
@@ -1,0 +1,79 @@
+# First run vs later runs
+
+
+The only state loupe keeps is a SHA inside its own comments. Each reviewer keeps its own.
+
+## Decision
+
+```mermaid
+flowchart TD
+    S[Start reviewer] --> F{full forced?}
+    F -->|"@loupe review or full: true"| FULL
+    F -->|no| R[Find newest summary comment by me with loupe:summary:reviewer marker]
+    R -->|none| R2[Fallback: newest review body by me with loupe:reviewer marker]
+    R2 -->|none| FULL[Full run]
+    R -->|sha found| C{"sha equals head?"}
+    R2 -->|sha found| C
+    C -->|yes| FULL
+    C -->|no| CMP[repos.compareCommits sha..head]
+    CMP -->|error| FULL
+    CMP -->|delta| INC[Incremental run over in-scope delta files]
+    INC -->|0 files| KEEP[Post nothing, keep prior comments]
+```
+
+The "sha equals head" case happens on `reopened` or `ready_for_review` with no new commits, and on a manual re-run. Treating it as a full run means the review is recomputed and replaced, not skipped.
+
+## First run
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GH as GitHub
+    participant L as loupe (one reviewer)
+    participant W as agent
+    GH->>L: pull_request opened, head = A
+    L->>GH: listComments, listReviews
+    Note over L: no markers → full run over all in-scope files
+    L->>W: review 12 files
+    W-->>L: 3 findings
+    L->>GH: createReview COMMENT + 3 inline (marker sha=A)
+    L->>GH: createComment summary (marker summary sha=A)
+```
+
+## Second push
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GH as GitHub
+    participant L as loupe (one reviewer)
+    participant W as agent
+    GH->>L: pull_request synchronize, head = B
+    L->>GH: listComments → summary marker sha=A
+    L->>GH: compareCommits A..B → 2 files changed
+    Note over L: incremental: review only those 2 files
+    L->>W: review 2 files
+    W-->>L: 1 finding
+    L->>GH: listReviewComments → delete my comments on those 2 files only
+    L->>GH: createReview COMMENT + 1 inline (marker sha=B)
+    L->>GH: updateComment summary (stats for 2 files, marker sha=B)
+```
+
+Comments on the other 10 files from the first run are untouched. GitHub shows them as outdated if their lines moved.
+
+## Push that changes nothing in scope
+
+Head moves to C, `compareCommits B..C` returns only files outside this reviewer's globs. The reviewer logs "keeping prior comments" and makes no writes. The summary still says `sha=B`, so the next push compares from B, not C.
+
+## Forced full run
+
+`@loupe review` calls the same pipeline with `full = true`. Every in-scope file is reviewed, every prior inline comment for this reviewer is deleted, and the summary is rewritten with a fresh stat line.
+
+## Consequences worth knowing
+
+- **The summary stat line reflects the last run only.** After an incremental run over 2 files it says "2 files", not the PR total.
+- **A stale `REQUEST_CHANGES` review persists.** Fixing the blocker and pushing yields a new `COMMENT` review. The old request stays until dismissed.
+- **Deleting the summary comment resets the reviewer to first-run behavior** on the next push, unless an older review body still carries a marker.
+- **N reviewers, N SHAs.** A reviewer whose globs never matched has no summary on the PR, so its first match is a full run.
+
+Next: [@loupe chat](./chat.md).

--- a/docs/how-it-works/github-objects.md
+++ b/docs/how-it-works/github-objects.md
@@ -1,0 +1,105 @@
+# GitHub objects
+
+
+Three kinds of object, all owned by loupe's TypeScript, never by the agent.
+
+| Object | API | Per run | Marker |
+| --- | --- | --- | --- |
+| Pull request review | `pulls.createReview` | 0 or 1, only if there are inline findings or a blocker | `<!-- loupe:<reviewer> sha=<head> -->` in the body when no inline comments |
+| Inline review comment | created inside the review above, deleted via `pulls.deleteReviewComment` | n | Same marker appended to every comment body |
+| Summary issue comment | `issues.createComment` first time, `issues.updateComment` after | exactly 1, updated in place | `<!-- loupe:summary:<reviewer> sha=<head> -->` |
+
+`<reviewer>` is the reviewer's `name` (or `default` with no config), so reviewers never touch each other's objects.
+
+## The posting sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant L as loupe
+    participant GH as GitHub API
+    L->>GH: users.getAuthenticated
+    Note over L,GH: Actions token cannot; falls back to github-actions[bot]
+    L->>GH: pulls.listReviewComments
+    loop each prior comment by me, with my marker, on a refreshed path
+        L->>GH: pulls.deleteReviewComment
+    end
+    alt inline findings or a blocker concern
+        L->>GH: pulls.createReview(event, body, comments[])
+    end
+    L->>GH: issues.listComments
+    alt summary comment by me exists
+        L->>GH: issues.updateComment
+    else
+        L->>GH: issues.createComment
+    end
+```
+
+## Review verdict
+
+```mermaid
+flowchart LR
+    F[inline findings + concerns] --> B{any blocker?}
+    B -->|yes| RC[REQUEST_CHANGES]
+    B -->|no| I{any inline finding?}
+    I -->|yes| CM[COMMENT]
+    I -->|no| N[No review object, summary comment only]
+```
+
+- **`REQUEST_CHANGES`** counts as a blocking review in the PR UI until dismissed. A later run with no blockers posts a `COMMENT` review, which does not dismiss the earlier request. Dismiss it by hand.
+- **Never `APPROVE`.** A bot must not satisfy a required-approver rule.
+- **Review body** is empty when there are inline comments. GitHub requires some body when there are none, so a blocker-only review carries just the marker.
+
+## Inline comment body
+
+```
+🔴 **blocker** <finding body>
+
+<!-- loupe:<reviewer> sha=<head> -->
+```
+
+Severity emoji: 🔴 blocker, 🟡 warning, 🔵 nit.
+
+## Summary comment body
+
+~~~
+### 🔍 loupe · <reviewer>
+
+🔴 1 · 🟡 2 · 4 files
+
+<summary from the agent>
+
+#### Concerns
+- 🟡 **title** — detail
+
+#### Highlights
+- ✅ ...
+
+_3 inline comments on the diff below._
+
+```mermaid   (only if the agent returned a diagram)
+...
+```
+
+<details><summary>Other notes (n)</summary> off-diff findings </details>
+
+Last reviewed commit: [`abc1234`](link)
+
+<!-- loupe:summary:<reviewer> sha=<head> -->
+~~~
+
+In ensemble mode, minority findings sit in a second `<details>` block titled "Lower-confidence findings".
+
+## Author guard
+
+A marker in a comment body is not proof loupe wrote it. A person quoting a loupe comment carries the marker too. Every "is this mine" check pairs the marker with the login from `users.getAuthenticated`, or `github-actions[bot]` when that call fails, which it does for the default Actions token. Only comments under that login are deleted or read for the last-reviewed SHA.
+
+## What gets deleted
+
+- **Full run:** every inline comment by loupe with this reviewer's marker.
+- **Incremental run:** only those on files in the delta. Comments on files unchanged since the last review stay.
+- **Never:** the summary comment (updated in place), reviews themselves (GitHub does not allow deleting reviews), human comments, other reviewers' comments.
+
+Cleanup is best-effort. A failure logs a warning and posting proceeds, which can leave a duplicate.
+
+Next: [First run vs later runs](./first-vs-incremental.md).

--- a/docs/how-it-works/github-objects.md
+++ b/docs/how-it-works/github-objects.md
@@ -19,7 +19,7 @@ sequenceDiagram
     participant L as loupe
     participant GH as GitHub API
     L->>GH: users.getAuthenticated
-    Note over L,GH: Actions token cannot; falls back to github-actions[bot]
+    Note over L,GH: Actions token cannot, so it falls back to github-actions[bot]
     L->>GH: pulls.listReviewComments
     loop each prior comment by me, with my marker, on a refreshed path
         L->>GH: pulls.deleteReviewComment

--- a/docs/how-it-works/review-run.md
+++ b/docs/how-it-works/review-run.md
@@ -1,0 +1,80 @@
+# A review run
+
+
+`runReviews` fans out one `runReview` per reviewer in `.loupe.json`, in parallel. Everything below happens once per reviewer. Code: `packages/core/src/index.ts`.
+
+## Pipeline
+
+```mermaid
+flowchart TD
+    A[Fetch PR + changed files + convention docs] --> B[Scope: dir, include, exclude]
+    B -->|0 files| Z1[Return: nothing to review]
+    B --> C{full run?}
+    C -->|no| D[Read last-reviewed SHA from markers]
+    D -->|found and differs from head| E[Compare SHAs, keep only files in delta]
+    E -->|0 files| Z2[Return: keep prior comments]
+    D -->|none or equals head| F
+    C -->|yes| F[Files = all in scope]
+    E --> F
+    F --> G[Write diff to temp file, build prompts]
+    G --> H[Agent run, maxTurns cap]
+    H -->|error| H2[Retry one-shot from inline diff]
+    H --> I[Parse last JSON object]
+    H2 --> I
+    I --> J[Anchor findings to diff lines, snap within 10]
+    J --> K[Drop severities outside profile]
+    K -->|findings > 0| L[Verify pass: one-shot second opinion]
+    K -->|0 findings| M
+    L --> M[Post review + summary]
+```
+
+## Step by step
+
+1. **Fetch.** GitHub reads in parallel: `pulls.get`, `pulls.listFiles` (paginated, with patches), and `repos.getContent` for each convention doc at the PR head. Convention paths default to `CLAUDE.md, AGENTS.md, .loupe.md, CONTRIBUTING.md`, prefixed with `dir` when set.
+2. **Scope.** Keep files under `dir` that match the reviewer's `include` and miss its `exclude`. Zero files means the reviewer is skipped with no GitHub writes.
+3. **Incremental or full.** See [First run vs later runs](./first-vs-incremental.md). Default is incremental. `@loupe review` and the `full` input force full.
+4. **Prompts.** The diff is rendered as `### <path>` sections and written to a temp file. The user prompt carries a file tree plus that path. See [What the agent sees](./context.md).
+5. **Run the agent.** For whip: `whip run --format json -quiet -no-session -max-turns <n> -system <prompt> -m <model> -cache-key loupe/<owner>/<repo>/<reviewer>`, prompt on stdin, in a throwaway `WHIP_HOME` built from the config's `whip` block. `claude` and `codex` get the equivalent flags. If the agentic run throws, loupe retries once headless with the full diff inlined so something still posts.
+6. **Parse.** The last `{...}` in stdout is the review. Each finding is validated on its own, so one malformed entry is dropped rather than failing the run. Off-scale severities (`critical`, `minor`, ...) map onto blocker, warning, nit.
+7. **Anchor.** GitHub only accepts inline comments on lines present in the diff. A finding on an exact diff line stays inline. One within 10 lines snaps to the nearest diff line. Anything else, or on a file not in scope, becomes an off-diff note in the summary.
+8. **Profile filter.** `quiet` keeps blockers, `chill` (default) keeps blockers and warnings, `assertive` keeps everything.
+9. **Verify.** If any inline findings survived and `verify` is on (default), one more headless call asks the same model to mark each `real: true|false`. Findings judged not real are dropped. Any error keeps them all. An `ensemble` replaces this step: findings a majority of models agree on are kept, minority findings go to a collapsed section.
+10. **Post.** See [GitHub objects](./github-objects.md).
+
+## Limits
+
+| Knob | Default | Effect |
+| --- | --- | --- |
+| `maxTurns` | 10 | Agentic tool-loop cap, per reviewer or top level |
+| headless cap | 10, fixed | Safety net for the verify pass and the one-shot retry |
+| `reasoning` | low | Changes one sentence in the system prompt, nothing else |
+
+Hitting `maxTurns` mid-exploration is an error from the harness, which triggers the headless retry.
+
+## Sequence, single reviewer, happy path
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant L as loupe core
+    participant GH as GitHub API
+    participant W as agent CLI
+    participant FS as checkout + /tmp
+
+    L->>GH: pulls.get, pulls.listFiles, repos.getContent per convention doc
+    L->>GH: issues.listComments (find last-reviewed SHA)
+    L->>GH: repos.compareCommits(prior, head)
+    L->>FS: write /tmp/loupe-diff-*/pr.diff
+    L->>W: spawn agent (system prompt, user prompt)
+    loop up to maxTurns
+        W->>FS: read files, grep diff
+    end
+    W-->>L: stdout with JSON review
+    L->>W: spawn agent (verify prompt, headless)
+    W-->>L: verdicts JSON
+    L->>GH: pulls.listReviewComments, pulls.deleteReviewComment x n
+    L->>GH: pulls.createReview (inline comments)
+    L->>GH: issues.updateComment or issues.createComment (summary)
+```
+
+Next: [What the agent sees](./context.md).

--- a/docs/how-it-works/triggers.md
+++ b/docs/how-it-works/triggers.md
@@ -1,0 +1,53 @@
+# Triggers
+
+
+Two workflows, one action. They are separate files so neither shows as a perpetually skipped job on the other's events. loupe ships templates for both in its `examples/` and `.github/workflows/` directories.
+
+| Workflow | Event | Runs when | Permissions |
+| --- | --- | --- | --- |
+| review | `pull_request`: opened, synchronize, reopened, ready_for_review | PR is not a draft, optionally filtered by `paths` | `pull-requests: write`, `contents: read` |
+| chat | `issue_comment`, `pull_request_review_comment` (created) | Comment is on a PR and contains `@loupe` | `pull-requests: write`, `contents: write` (for `@loupe fix`) |
+
+## Decision flow
+
+```mermaid
+flowchart TD
+    E[GitHub event] --> T{Event type}
+    T -->|pull_request| D{Draft?}
+    D -->|yes| S1[Skip]
+    D -->|no| P{"Matches paths filter?"}
+    P -->|no| S1
+    P -->|yes| C1[Cancel in-flight review for this PR]
+    C1 --> R[Review job]
+    T -->|issue_comment or review_comment| ISPR{On a PR?}
+    ISPR -->|no| S1
+    ISPR -->|yes| M{Body contains @loupe?}
+    M -->|no| S1
+    M -->|yes| Q[Queue behind any running chat job for this PR]
+    Q --> CH[Chat job]
+```
+
+## Concurrency
+
+- **Review:** group `loupe-review-<pr>`, `cancel-in-progress: true`. A push while a review is running kills the old run; the new run reviews the new head.
+- **Chat:** group `loupe-chat-<pr>`, `cancel-in-progress: false`. Two mentions in quick succession run one after the other, so a `fix` is never half-pushed.
+
+## Job setup (both workflows)
+
+1. `actions/checkout` at the PR merge ref. The agent's tools read this checkout.
+2. Install the harness CLI (`whip`, `claude`, or `codex`).
+3. Provide the model provider's API key as an environment variable. Where it comes from (repo secret, Infisical, Vault) is the workflow's business, not loupe's.
+4. `uses: context-labs/loupe@main` with `config: <path to .loupe.json>`.
+
+Making every step `continue-on-error: true` keeps a loupe failure from blocking a merge.
+
+## Inside the action
+
+The action reads `GITHUB_EVENT_NAME` and branches once:
+
+- `issue_comment` or `pull_request_review_comment` → [chat handler](./chat.md).
+- anything else → [review run](./review-run.md) for every reviewer in the config.
+
+The PR number comes from the event payload (`pull_request.number` or `issue.number`), or from `LOUPE_PR_NUMBER` when run from the CLI.
+
+Next: [A review run](./review-run.md).


### PR DESCRIPTION
## What

`docs/how-it-works/` — 7 pages with mermaid diagrams on how loupe behaves for any repo using it: triggers, the per-reviewer pipeline, the exact context the agent sees, every GitHub object loupe creates/updates/deletes and the markers tying them together, first vs incremental runs, and `@loupe` chat. Linked from `docs/README.md`. Configuration stays in the existing `docs/configuration.md`.

Written against `main` at `8fd1cc7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)