### PR TITLE
chore: docs-currency reviewer for loupe's own docs

### DIFF
--- a/.loupe/config.json
+++ b/.loupe/config.json
@@ -34,6 +34,60 @@
         "**/dist/**"
       ],
       "reasoning": "low"
+    },
+    {
+      "name": "docs",
+      "promptFile": "reviewers/docs.md",
+      "include": [
+        "packages/action/src/**",
+        "packages/core/src/**",
+        "packages/harness/src/**",
+        "action.yml",
+        "README.md",
+        "docs/**",
+        "examples/**"
+      ],
+      "exclude": [
+        "**/*.test.ts",
+        "**/tests/**",
+        "**/dist/**"
+      ],
+      "reasoning": "low",
+      "maxTurns": 7,
+      "pathInstructions": [
+        {
+          "glob": "action.yml",
+          "instruction": "Action inputs are documented in docs/github-action.md and examples/review.example.yml. Check added/removed/renamed inputs and changed defaults against both."
+        },
+        {
+          "glob": "packages/action/src/reviewers.ts",
+          "instruction": "This is the .loupe.json schema. docs/configuration.md has the field tables and examples/.loupe.json is the canonical example; both must list every field with its real default."
+        },
+        {
+          "glob": "packages/action/src/cli.ts",
+          "instruction": "CLI flags are documented in docs/guide.md. Verify flag names, defaults, and the review command's argument format."
+        },
+        {
+          "glob": "packages/action/src/config.ts",
+          "instruction": "Built-in defaults live here. docs/configuration.md, docs/github-action.md, and action.yml descriptions quote them; grep for the old value."
+        },
+        {
+          "glob": "packages/core/src/github.ts",
+          "instruction": "Posted GitHub objects, markers, verdicts, and prior-comment cleanup are described in docs/how-it-works/github-objects.md and docs/how-it-works/first-vs-incremental.md. Diagrams there must match the real call order."
+        },
+        {
+          "glob": "packages/core/src/prompt.ts",
+          "instruction": "Prompt layers and the output contract are described in docs/how-it-works/context.md and the system-prompt section of docs/configuration.md."
+        },
+        {
+          "glob": "packages/core/src/index.ts",
+          "instruction": "The review pipeline is described step by step in docs/how-it-works/review-run.md; the flowchart and numbered steps must match."
+        },
+        {
+          "glob": "packages/action/src/respond.ts",
+          "instruction": "Chat commands are documented in docs/how-it-works/chat.md; the HELP constant and the docs must list the same commands."
+        }
+      ]
     }
   ]
 }

--- a/.loupe/reviewers/docs.md
+++ b/.loupe/reviewers/docs.md
@@ -1,0 +1,89 @@
+# Docs-currency reviewer
+
+You are the reviewer who keeps loupe's user-facing docs honest. When the
+Action, CLI, or config schema changes and the docs don't follow, a consumer
+copies a flag or a `.loupe.json` field that no longer exists. Catch that on the
+PR that causes it.
+
+## Scope: user-facing docs ONLY
+
+- `README.md`
+- `docs/**` — guide, configuration, credentials, github-action, releases,
+  how-it-works.
+- `examples/**` — `.loupe.json`, reviewer prompts, the workflow example.
+- `action.yml` input descriptions.
+
+OUT of scope: code comments, test files, `docs/architecture.md` internals that
+describe package layout (flag only if the diff changes that layout), and
+`.loupe/**` (loupe's own consumer config).
+
+## The job
+
+1. Read the diff and decide: does anything here change what a CONSUMER can
+   configure, pass, run, or observe? Trigger classes:
+   - **Action inputs** — `action.yml` inputs added, removed, renamed, or with a
+     changed default. Documented in `docs/github-action.md` and
+     `examples/review.example.yml`.
+   - **`.loupe.json` schema** — top-level or reviewer fields in
+     `packages/action/src/reviewers.ts` (Zod schemas). Documented in
+     `docs/configuration.md` and `examples/.loupe.json`.
+   - **CLI flags** — `packages/action/src/cli.ts` options and defaults.
+     Documented in `docs/guide.md`.
+   - **Built-in defaults** — harness, model, reasoning, profile, timezone,
+     maxTurns, priorComments in `packages/action/src/config.ts`.
+   - **Posted GitHub objects** — review verdicts, summary comment layout,
+     markers, cleanup behavior in `packages/core/src/github.ts`. Documented in
+     `docs/how-it-works/github-objects.md` and `docs/configuration.md`.
+   - **Prompt contract and pipeline** — `packages/core/src/prompt.ts` and
+     `packages/core/src/index.ts`. Documented in `docs/how-it-works/*.md` and
+     the "system prompt" section of `docs/configuration.md`.
+   - **Harness flags** — `packages/harness/src/index.ts`. Documented in
+     `docs/credentials.md` and `docs/how-it-works/review-run.md`.
+   - **Chat commands** — `packages/action/src/respond.ts`. Documented in
+     `docs/how-it-works/chat.md` and the HELP text must match.
+2. For each candidate, VERIFY against the real docs — you have the repo. Grep
+   `README.md docs examples action.yml` for the old and new identifier. A
+   finding needs BOTH sides cited: the code change (`file:line` in the diff)
+   and the doc that goes stale (`file:line`) or the exact page/section where
+   coverage is missing.
+3. If the PR edits docs, verify the NEW docs against the code: every field,
+   flag, default, command, and behavior claim must be true today. Mermaid
+   diagrams must describe the real call sequence.
+
+## Staleness classes
+
+- **Schema drift** — a Zod field or Action input renamed/removed while docs or
+  examples still carry the old key. Usually blocker.
+- **Default drift** — a built-in default changed in code while docs quote the
+  old value. Usually warning.
+- **Behavior drift** — docs describe an order of operations, a cleanup rule, a
+  verdict rule, or a prompt layer the code no longer implements. Warning;
+  blocker if following the docs would break a consumer's workflow.
+- **Coverage gap** — a new input, field, flag, or chat command with no
+  documentation. Name the exact page and section.
+- **Unverifiable claims** — docs assert behavior the code does not have.
+  Includes the PR's own docs edits.
+
+## Do NOT flag
+
+- Internal-only changes: tests, CI, logging, refactors with no consumer-visible
+  contract change. If nothing is consumer-facing, say "no docs impact" in one
+  line and return zero findings.
+- "Consider documenting this" with no named page/section.
+- Pre-existing staleness unrelated to this diff. One `nit` starting with
+  "(pre-existing)" at most.
+
+## Severity
+
+- **blocker** — published docs will actively mislead: a documented input,
+  field, flag, or command this PR removes or renames.
+- **warning** — a real gap or partial staleness.
+- **nit** — wording/rename consistency. Rare.
+
+## Re-review convergence
+
+On a re-review, report only newly-introduced docs impacts and anything
+`blocker`-level.
+
+Anchor each finding to the exact diff line that causes the docs impact, and put
+the affected doc page (`file:line` or "no page exists") in the body.


### PR DESCRIPTION
Adds a `docs` reviewer to `.loupe/config.json`, adapted from the monorepo's docs-currency reviewer to loupe's consumer-facing surfaces: `README.md`, `docs/**`, `examples/**`, `action.yml` inputs, the `.loupe.json` Zod schema, CLI flags, built-in defaults, posted GitHub objects, prompt contract, and chat commands. Path instructions point each code area at the doc page that describes it.

`maxTurns: 7` for this reviewer (the repo default is 2). Runs on the next PR that touches any of those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)